### PR TITLE
Rework speaking new text and add a hyperlinks rotor

### DIFF
--- a/application/GlkController.h
+++ b/application/GlkController.h
@@ -22,7 +22,7 @@
 
 @end
 
-@interface GlkController : NSWindowController {
+@interface GlkController : NSWindowController <NSAccessibilityCustomRotorItemSearchDelegate> {
     /* for talking to the interpreter */
     NSTask *task;
     NSFileHandle *readfh;
@@ -129,6 +129,7 @@
 @property BOOL beyondZork;
 @property BOOL kerkerkruip;
 @property BOOL thaumistry;
+@property BOOL colderLight;
 
 @property NSInteger autosaveVersion;
 @property NSInteger autosaveTag;
@@ -137,9 +138,10 @@
 @property BOOL voiceOverActive;
 
 @property ZMenu *zmenu;
-@property BOOL hasSpokenMenuThisTurn;
 @property BOOL shouldCheckForMenu;
-
+@property BOOL shouldSpeakNewText;
+@property NSDate *speechTimeStamp;
+@property GlkWindow *spokeLast;
 
 - (void)runTerp:(NSString *)terpname
        withGame:(Game *)game
@@ -160,5 +162,10 @@
 - (void)storeScrollOffsets;
 - (void)restoreScrollOffsets;
 - (void)adjustContentView;
+
+- (NSArray *)createCustomRotors;
+- (NSAccessibilityCustomRotorItemResult *)rotor:(NSAccessibilityCustomRotor *)rotor
+                      resultForSearchParameters:(NSAccessibilityCustomRotorSearchParameters *)searchParameters API_AVAILABLE(macos(10.13));
+
 
 @end

--- a/application/GlkTextBufferWindow.h
+++ b/application/GlkTextBufferWindow.h
@@ -106,6 +106,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(readonly) NSInteger lastchar; /* for smart formatting */
 @property(readonly) NSInteger lastseen; /* for more paging */
+@property NSUInteger printPositionOnInput; // for keeping track of previous moves
 
 /* For autorestoring scroll position */
 @property NSUInteger restoredLastVisible;
@@ -139,7 +140,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (IBAction)speakPrevious:(nullable id)sender;
 - (IBAction)speakNext:(nullable id)sender;
 - (IBAction)speakStatus:(nullable id)sender;
-- (void)setLastMove;
+- (BOOL)setLastMove;
 
 @end
 

--- a/application/GlkTextGridWindow.h
+++ b/application/GlkTextGridWindow.h
@@ -39,10 +39,13 @@
 @property NSString *enteredTextSoFar;
 
 @property BOOL usingStyles;
+@property BOOL hasNewText;
 
 - (BOOL)myMouseDown:(NSEvent *)theEvent;
 - (IBAction)speakStatus:(id)sender;
+- (BOOL)setLastMove;
 - (void)deferredGrabFocus:(id)sender;
 - (void)recalcBackground;
+- (void)speakMostRecent:(id)sender;
 
 @end

--- a/application/GlkWindow.h
+++ b/application/GlkWindow.h
@@ -80,4 +80,6 @@ struct fillrect;
 
 - (BOOL)hasCharRequest;
 
+- (NSArray *)links;
+
 @end

--- a/application/GlkWindow.m
+++ b/application/GlkWindow.m
@@ -259,6 +259,11 @@ fprintf(stderr, "%s\n",                                                    \
     return char_request;
 }
 
+- (NSArray *)links {
+    NSLog(@"links in %@ not implemented", [self class]);
+    return @[];
+}
+
 #pragma mark -
 #pragma mark Windows restoration
 
@@ -270,6 +275,10 @@ fprintf(stderr, "%s\n",                                                    \
 
 - (BOOL)accessibilityIsIgnored {
     return NO;
+}
+
+- (NSArray *)accessibilityCustomRotors  {
+   return [self.glkctl createCustomRotors];
 }
 
 @end

--- a/application/ZMenu.m
+++ b/application/ZMenu.m
@@ -89,6 +89,7 @@
             if (_glkctl.beyondZork) {
                 _menuCommands = [self extractMenuCommandsUsingRegex:@"(Function (Key) Definitions)"];
                 if (!_menuCommands.count) {
+                    NSLog(@"Found no menu commands. Not a menu");
                     return NO;
                 } else {
                     // If in the Definitions menu, add the last two lines
@@ -113,8 +114,10 @@
     _selectedLine = [self findSelectedLine];
 
     // If we find no currently selected line, decide this is not a menu
-    if (_selectedLine == NSNotFound)
+    if (_selectedLine == NSNotFound) {
+        NSLog(@"Found no selected line. Not a menu");
         return NO;
+    }
 
     //    NSLog(@"We are in a menu!");
     //    NSLog(@"It has %ld lines:", _lines.count);
@@ -569,7 +572,7 @@
 }
 
 - (void)speakSelectedLine {
-    [self performSelector:@selector(deferredSpeakSelectedLine:) withObject:nil afterDelay:0.1];
+    [self performSelector:@selector(deferredSpeakSelectedLine:) withObject:nil afterDelay:0.2];
 }
 
 -(void)deferredSpeakSelectedLine:(id)sender {
@@ -606,6 +609,14 @@
         selectedLineString = [titleString stringByAppendingString:selectedLineString];
         _haveSpokenMenu = YES;
     }
+
+    if (_glkctl.beyondZork) {
+        id delegate = ((NSTextStorage *)_attrStr).delegate;
+        if ([delegate isKindOfClass:[GlkTextGridWindow class]] && ((GlkTextGridWindow *)delegate).input) {
+            selectedLineString = [selectedLineString stringByAppendingString:((GlkTextGridWindow *)delegate).enteredTextSoFar];
+        }
+    }
+
     [self speakString:selectedLineString];
     [NSObject cancelPreviousPerformRequestsWithTarget:self];
     [self performSelector:@selector(speakInstructions:) withObject:nil afterDelay:5];


### PR DESCRIPTION
Reworks automatic speaking new text by looking through all Glk windows for new text, rather than just the one currently in focus. This fixes the reading of text games that separate input and display of text, such as Tads 3 menus.

Also added a custom hyperlink rotor that lists (most) current hyperlinks in all windows. The Colder Light and Dead Cities should now be playable using only this rotor (or the system object chooser rotor.)