### PR TITLE
Centralize the speak last/next/previous move functionality for all windows

### DIFF
--- a/application/GlkController.h
+++ b/application/GlkController.h
@@ -163,6 +163,11 @@
 - (void)restoreScrollOffsets;
 - (void)adjustContentView;
 
+- (IBAction)speakMostRecent:(id)sender;
+- (IBAction)speakPrevious:(id)sender;
+- (IBAction)speakNext:(id)sender;
+- (IBAction)speakStatus:(id)sender;
+
 - (NSArray *)createCustomRotors;
 - (NSAccessibilityCustomRotorItemResult *)rotor:(NSAccessibilityCustomRotor *)rotor
                       resultForSearchParameters:(NSAccessibilityCustomRotorSearchParameters *)searchParameters API_AVAILABLE(macos(10.13));

--- a/application/GlkController.m
+++ b/application/GlkController.m
@@ -3615,9 +3615,11 @@ enterFullScreenAnimationWithDuration:(NSTimeInterval)duration {
 
     if (rotor.type == NSAccessibilityCustomRotorTypeAny) {
         return [self textSearchResultForString:filterText fromRange: currentRange direction:direction];
-    }
-
-    if (rotor.type == NSAccessibilityCustomRotorTypeLink) {
+    } else if ([rotor.label isEqualToString:NSLocalizedString(@"Command history", nil)]) {
+        return [self commandHistoryRotor:rotor resultForSearchParameters:searchParameters];
+    } else if ([rotor.label isEqualToString:NSLocalizedString(@"Game windows", nil)]) {
+        return [self glkWindowRotor:rotor resultForSearchParameters:searchParameters];
+    } else if (rotor.type == NSAccessibilityCustomRotorTypeLink) {
         NSArray *allWindows = _gwindows.allValues;
         if (_colderLight && allWindows.count == 5) {
             allWindows = @[_gwindows[@(3)], _gwindows[@(4)], _gwindows[@(0)], _gwindows[@(1)]];
@@ -3680,7 +3682,6 @@ enterFullScreenAnimationWithDuration:(NSTimeInterval)duration {
         }
         searchResult.targetRange = textRange;
     }
-
     return searchResult;
 }
 
@@ -3730,6 +3731,130 @@ enterFullScreenAnimationWithDuration:(NSTimeInterval)duration {
     return searchResult;
 }
 
+- (NSAccessibilityCustomRotorItemResult *)glkWindowRotor:(NSAccessibilityCustomRotor *)rotor
+                     resultForSearchParameters:(NSAccessibilityCustomRotorSearchParameters *)searchParameters  API_AVAILABLE(macos(10.13)){
+
+    NSAccessibilityCustomRotorItemResult *searchResult = nil;
+
+    NSAccessibilityCustomRotorItemResult *currentItemResult = searchParameters.currentItem;
+    NSAccessibilityCustomRotorSearchDirection direction = searchParameters.searchDirection;
+
+    NSArray *children = _gwindows.allValues;
+
+    NSUInteger currentItemIndex = [children indexOfObject:currentItemResult.targetElement];
+
+     if (currentItemIndex == NSNotFound) {
+        // Find the start or end element.
+        if (direction == NSAccessibilityCustomRotorSearchDirectionNext) {
+            currentItemIndex = 0;
+        } else if (direction == NSAccessibilityCustomRotorSearchDirectionPrevious) {
+            currentItemIndex = children.count - 1;
+        }
+    } else {
+        if (direction == NSAccessibilityCustomRotorSearchDirectionPrevious) {
+            if (currentItemIndex == 0) {
+                currentItemIndex = NSNotFound;
+            } else {
+                currentItemIndex--;
+            }
+        } else if (direction == NSAccessibilityCustomRotorSearchDirectionNext) {
+            if (currentItemIndex == children.count - 1) {
+                currentItemIndex = NSNotFound;
+            } else {
+                currentItemIndex++;
+            }
+        }
+    }
+
+    if (currentItemIndex == NSNotFound) {
+        return nil;
+    }
+
+    GlkWindow *targetWindow = children[currentItemIndex];
+
+    NSLog (@"targetWindow = %@", targetWindow);
+
+    if (targetWindow) {
+        searchResult = [[NSAccessibilityCustomRotorItemResult alloc] initWithTargetElement: targetWindow];
+        NSString *contentString = @"";
+        if (![targetWindow isKindOfClass:[GlkGraphicsWindow class]] && ((GlkTextBufferWindow *)targetWindow).textview) {
+            contentString = ((GlkTextBufferWindow *)targetWindow).textview.string.copy;
+            if (contentString.length > 80)
+                contentString = [contentString substringToIndex:79];
+        }
+        NSString *kindString;
+        if ([targetWindow isKindOfClass:[GlkGraphicsWindow class]]) {
+            kindString = @"Graphics";
+        } else if ([targetWindow isKindOfClass:[GlkTextGridWindow class]]) {
+            kindString = @"Grid text";
+        } else {
+            kindString = @"Buffer text";
+
+        }
+        searchResult.customLabel = [NSString stringWithFormat:@"%@ window%@%@", kindString, (contentString.length) ? @": " : @"", contentString];
+    }
+
+    return searchResult;
+}
+
+- (NSAccessibilityCustomRotorItemResult *)commandHistoryRotor:(NSAccessibilityCustomRotor *)rotor
+                      resultForSearchParameters:(NSAccessibilityCustomRotorSearchParameters *)searchParameters  API_AVAILABLE(macos(10.13)){
+
+    NSAccessibilityCustomRotorItemResult *searchResult = nil;
+
+    NSAccessibilityCustomRotorSearchDirection direction = searchParameters.searchDirection;
+    NSRange currentRange = searchParameters.currentItem.targetRange;
+
+    GlkTextBufferWindow *largest = [self largestWithMoves];
+    if (!largest)
+        return nil;
+
+    NSArray *children =  [[largest.moveRanges reverseObjectEnumerator] allObjects];
+
+    NSUInteger currentItemIndex = [children indexOfObject:[NSValue valueWithRange:currentRange]];
+
+     if (currentItemIndex == NSNotFound) {
+        // Find the start or end element.
+        if (direction == NSAccessibilityCustomRotorSearchDirectionNext) {
+            currentItemIndex = 0;
+        } else if (direction == NSAccessibilityCustomRotorSearchDirectionPrevious) {
+            currentItemIndex = children.count - 1;
+        }
+        NSLog(@"found no currentRange in children, setting it to %ld", currentItemIndex);
+    } else {
+        NSLog(@"found currentRange at index %ld", currentItemIndex);
+        if (direction == NSAccessibilityCustomRotorSearchDirectionPrevious) {
+            if (currentItemIndex == 0) {
+                currentItemIndex = NSNotFound;
+            } else {
+                currentItemIndex--;
+            }
+        } else if (direction == NSAccessibilityCustomRotorSearchDirectionNext) {
+            if (currentItemIndex == children.count - 1) {
+                currentItemIndex = NSNotFound;
+            } else {
+                currentItemIndex++;
+            }
+        }
+    }
+
+    if (currentItemIndex == NSNotFound) {
+        return nil;
+    }
+
+    NSValue *targetRangeValue = children[currentItemIndex];
+
+    if (targetRangeValue) {
+        NSRange textRange = targetRangeValue.rangeValue;
+        searchResult = [[NSAccessibilityCustomRotorItemResult alloc] initWithTargetElement:largest.textview];
+        searchResult.targetRange = textRange;
+        // By adding a custom label, all ranges are reliably listed in the rotor
+        searchResult.customLabel = [largest.textview.string substringWithRange:textRange];
+    }
+
+    return searchResult;
+}
+
 - (NSArray *)createCustomRotors {
     if (@available(macOS 10.13, *)) {
         NSMutableArray *rotorsArray = [[NSMutableArray alloc] init];
@@ -3749,6 +3874,16 @@ enterFullScreenAnimationWithDuration:(NSTimeInterval)duration {
         // Create the text search rotor.
         NSAccessibilityCustomRotor *textSearchRotor = [[NSAccessibilityCustomRotor alloc] initWithRotorType:NSAccessibilityCustomRotorTypeAny itemSearchDelegate:self];
         [rotorsArray addObject:textSearchRotor];
+//        // Create the command history rotor
+        if ([self largestWithMoves]) {
+            NSAccessibilityCustomRotor *commandHistoryRotor = [[NSAccessibilityCustomRotor alloc] initWithLabel:NSLocalizedString(@"Command history", nil) itemSearchDelegate:self];
+            [rotorsArray addObject:commandHistoryRotor];
+        }
+        // Create the Glk windows rotor
+        if (_gwindows.count) {
+            NSAccessibilityCustomRotor *glkWindowRotor = [[NSAccessibilityCustomRotor alloc] initWithLabel:NSLocalizedString(@"Game windows", nil) itemSearchDelegate:self];
+            [rotorsArray addObject:glkWindowRotor];
+        }
         return rotorsArray;
     } else {
         return @[];

--- a/application/GlkTextBufferWindow.h
+++ b/application/GlkTextBufferWindow.h
@@ -88,7 +88,6 @@ NS_ASSUME_NONNULL_BEGIN
     InputHistory *history;
 
     /* For speaking previous moves */
-    NSMutableArray *moveRanges;
     NSUInteger moveRangeIndex;
 
     CGFloat lastLineheight;
@@ -106,7 +105,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(readonly) NSInteger lastchar; /* for smart formatting */
 @property(readonly) NSInteger lastseen; /* for more paging */
-@property NSUInteger printPositionOnInput; // for keeping track of previous moves
+// for keeping track of previous moves
+@property NSUInteger printPositionOnInput;
+@property NSMutableArray *moveRanges;
 
 /* For autorestoring scroll position */
 @property NSUInteger restoredLastVisible;
@@ -136,10 +137,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)restoreScrollBarStyle;
 - (void)restoreScroll:(nullable id)sender;
 
-- (IBAction)speakMostRecent:(nullable id)sender;
-- (IBAction)speakPrevious:(nullable id)sender;
-- (IBAction)speakNext:(nullable id)sender;
-- (IBAction)speakStatus:(nullable id)sender;
+- (void)speakMostRecent;
+- (void)deferredSpeakMostRecent:(id)sender;
+- (void)speakPrevious;
+- (void)speakNext;
 - (BOOL)setLastMove;
 
 @end

--- a/application/GlkTextBufferWindow.m
+++ b/application/GlkTextBufferWindow.m
@@ -923,13 +923,13 @@
     GlkTextBufferWindow *delegate = (GlkTextBufferWindow *)self.delegate;
 
     if ([action isEqualToString:@"Repeat last move"])
-        [delegate speakMostRecent:nil];
+        [delegate.glkctl speakMostRecent:nil];
     else if ([action isEqualToString:@"Speak move before"])
-        [delegate speakPrevious:nil];
+        [delegate.glkctl speakPrevious:nil];
     else if ([action isEqualToString:@"Speak move after"])
-        [delegate speakNext:nil];
+        [delegate.glkctl speakNext:nil];
     else if ([action isEqualToString:@"Speak status bar"])
-        [delegate speakStatus:nil];
+        [delegate.glkctl speakStatus:nil];
     else
         [super accessibilityPerformAction:action];
 }
@@ -988,7 +988,7 @@
 
         history = [[InputHistory alloc] init];
 
-        moveRanges = [[NSMutableArray alloc] init];
+        _moveRanges = [[NSMutableArray alloc] init];
         scrollview = [[NSScrollView alloc] initWithFrame:NSZeroRect];
 
         [self restoreScrollBarStyle];
@@ -1097,7 +1097,7 @@
 
         history = [decoder decodeObjectForKey:@"history"];
         _printPositionOnInput = (NSUInteger)[decoder decodeIntegerForKey:@"printPositionOnInput"];
-        moveRanges = [decoder decodeObjectForKey:@"moveRanges"];
+        _moveRanges = [decoder decodeObjectForKey:@"_moveRanges"];
         moveRangeIndex = (NSUInteger)[decoder decodeIntegerForKey:@"moveRangeIndex"];
         _lastchar = [decoder decodeIntegerForKey:@"lastchar"];
         _lastseen = [decoder decodeIntegerForKey:@"lastseen"];
@@ -1145,7 +1145,7 @@
     [encoder encodeInteger:(NSInteger)fence forKey:@"fence"];
     [encoder encodeObject:history forKey:@"history"];
     [encoder encodeInteger:(NSInteger)_printPositionOnInput forKey:@"printPositionOnInput"];
-    [encoder encodeObject:moveRanges forKey:@"moveRanges"];
+    [encoder encodeObject:_moveRanges forKey:@"_moveRanges"];
     [encoder encodeInteger:(NSInteger)moveRangeIndex forKey:@"moveRangeIndex"];
     [encoder encodeInteger:_lastchar forKey:@"lastchar"];
     [encoder encodeInteger:_lastseen forKey:@"lastseen"];
@@ -1528,8 +1528,8 @@
     _printPositionOnInput = 0;
     [container clearImages];
 
-    moveRanges = nil;
-    moveRanges = [[NSMutableArray alloc] init];
+    _moveRanges = nil;
+    _moveRanges = [[NSMutableArray alloc] init];
     moveRangeIndex = 0;
 
     if (currentZColor && currentZColor.bg != zcolor_Current && currentZColor.bg != zcolor_Default)
@@ -1591,7 +1591,7 @@
     line_request = save_request;
 
     [container clearImages];
-    moveRanges = [[NSMutableArray alloc] init];
+    _moveRanges = [[NSMutableArray alloc] init];
 }
 
 - (void)putString:(NSString *)str style:(NSUInteger)stylevalue {
@@ -2757,7 +2757,7 @@ willChangeSelectionFromCharacterRange:(NSRange)oldrange
     NSUInteger maxlength = textstorage.length;
 
     if (!maxlength) {
-        moveRanges = [[NSMutableArray alloc] init];
+        _moveRanges = [[NSMutableArray alloc] init];
         moveRangeIndex = 0;
         _printPositionOnInput = 0;
         return NO;
@@ -2766,17 +2766,17 @@ willChangeSelectionFromCharacterRange:(NSRange)oldrange
     NSRange currentMove = NSMakeRange(0, maxlength);
     NSRange allText = NSMakeRange(0, maxlength);
 
-    if (moveRanges.lastObject) {
-        lastMove = ((NSValue *)moveRanges.lastObject).rangeValue;
+    if (_moveRanges.lastObject) {
+        lastMove = ((NSValue *)_moveRanges.lastObject).rangeValue;
         if (NSMaxRange(lastMove) > maxlength) {
-//            NSLog(@"setLastMove removing last move object (because it goes past the end): \"%@\"", [self stringFromRangeVal:moveRanges.lastObject]);
-            [moveRanges removeLastObject];
+//          Removing last move object (because it goes past the end)
+            [_moveRanges removeLastObject];
         } else if (lastMove.length == maxlength) {
             return NO;
         } else {
             if (lastMove.location == _printPositionOnInput && lastMove.length != maxlength - _printPositionOnInput) {
-//                NSLog(@"setLastMove removing last move object (because it does not go all the way to the end): \"%@\"", [self stringFromRangeVal:moveRanges.lastObject]);
-                [moveRanges removeLastObject];
+//          Removing last move object (because it does not go all the way to the end)
+                [_moveRanges removeLastObject];
                 currentMove = NSMakeRange(_printPositionOnInput, maxlength);
             } else {
                 currentMove = NSMakeRange(NSMaxRange(lastMove),
@@ -2792,9 +2792,8 @@ willChangeSelectionFromCharacterRange:(NSRange)oldrange
     string = [string stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
     if (string.length == 0)
         return NO;
-    moveRangeIndex = moveRanges.count;
-    [moveRanges addObject:[NSValue valueWithRange:currentMove]];
-//    NSLog(@"setLastMove adding last move: \"%@\"", [self stringFromRangeVal:moveRanges.lastObject]);
+    moveRangeIndex = _moveRanges.count;
+    [_moveRanges addObject:[NSValue valueWithRange:currentMove]];
     return YES;
 }
 
@@ -2806,14 +2805,18 @@ willChangeSelectionFromCharacterRange:(NSRange)oldrange
     return string;
 }
 
-- (IBAction)speakMostRecent:(id)sender {
-//    NSLog(@"GlkTextBufferWindow %ld speakMostRecent:", self.name);
+- (void)deferredSpeakMostRecent:(id)sender {
+    [self speakMostRecent];
+}
+
+- (void)speakMostRecent {
+    NSLog(@"GlkTextBufferWindow %ld speakMostRecent:", self.name);
     if (self.glkctl.zmenu)
         [NSObject cancelPreviousPerformRequestsWithTarget:self.glkctl.zmenu];
-    if (!moveRanges.count)
+    if (!_moveRanges.count)
         return;
-    moveRangeIndex = moveRanges.count - 1;
-    NSRange lastMove = ((NSValue *)moveRanges.lastObject).rangeValue;
+    moveRangeIndex = _moveRanges.count - 1;
+    NSRange lastMove = ((NSValue *)_moveRanges.lastObject).rangeValue;
     NSRange allText = NSMakeRange(0, textstorage.length);
     lastMove = NSIntersectionRange(allText, lastMove);
 
@@ -2834,8 +2837,9 @@ willChangeSelectionFromCharacterRange:(NSRange)oldrange
     [self speakString:str];
 }
 
-- (IBAction)speakPrevious:(id)sender {
-   if (!moveRanges.count)
+- (void)speakPrevious {
+    NSLog(@"GlkTextBufferWindow %ld speakPrevious:", self.name);
+   if (!_moveRanges.count)
        return;
    NSString *prefix = @"";
    if (moveRangeIndex > 0) {
@@ -2844,42 +2848,28 @@ willChangeSelectionFromCharacterRange:(NSRange)oldrange
        prefix = @"At first move.\n";
        moveRangeIndex = 0;
    }
-   [self speakRange:((NSValue *)moveRanges[moveRangeIndex])
+   [self speakRange:((NSValue *)_moveRanges[moveRangeIndex])
     .rangeValue prefix:prefix];
 }
 
-- (IBAction)speakNext:(id)sender {
-   // NSLog(@"speakNext: moveRangeIndex; %ld", moveRangeIndex);
+- (void)speakNext {
+    NSLog(@"GlkTextBufferWindow %ld speakNext:", self.name);
    [self setLastMove];
-   if (!moveRanges.count)
+   if (!_moveRanges.count)
    {
        return;
    }
 
    NSString *prefix = @"";
 
-   if (moveRangeIndex < moveRanges.count - 1) {
+   if (moveRangeIndex < _moveRanges.count - 1) {
        moveRangeIndex++;
    } else {
        prefix = @"At last move.\n";
-       moveRangeIndex = moveRanges.count - 1;
-//       NSLog(@"speakNext:moveRangeIndex = %ld. moveRanges.count = %ld. moveRanges[moveRangeIndex].rangeValue = %@", moveRangeIndex, moveRanges.count, NSStringFromRange(((NSValue *)moveRanges[moveRangeIndex]).rangeValue));
+       moveRangeIndex = _moveRanges.count - 1;
    }
-   [self speakRange:((NSValue *)moveRanges[moveRangeIndex])
+   [self speakRange:((NSValue *)_moveRanges[moveRangeIndex])
     .rangeValue prefix:prefix];
-}
-
-- (IBAction)speakStatus:(id)sender {
-    GlkWindow *win;
-
-    // Try to find status window to pass this on to
-    for (win in [self.glkctl.gwindows allValues]) {
-        if ([win isKindOfClass:[GlkTextGridWindow class]]) {
-            [(GlkTextGridWindow *)win speakStatus:sender];
-            return;
-        }
-    }
-    NSLog(@"No status window found");
 }
 
 - (void)speakRange:(NSRange)aRange prefix:(NSString *)prefix {
@@ -2901,9 +2891,6 @@ willChangeSelectionFromCharacterRange:(NSRange)oldrange
 
     if ([string hasPrefix:@">"])
         string = [string substringFromIndex:1];
-
-//    NSLog(@"GlkTextBufferWindow %ld speakString:", self.name);
-//    NSLog(@"\"%@\"", string);
 
     NSDictionary *announcementInfo = @{
                                        NSAccessibilityPriorityKey : @(NSAccessibilityPriorityHigh),
@@ -2949,13 +2936,13 @@ willChangeSelectionFromCharacterRange:(NSRange)oldrange
     // NSLog(@"GlkTextBufferWindow: accessibilityPerformAction. %@",action);
 
     if ([action isEqualToString:@"Repeat last move"])
-        [self speakMostRecent:nil];
+        [self.glkctl speakMostRecent:nil];
     else if ([action isEqualToString:@"Speak move before"])
-        [self speakPrevious:nil];
+        [self.glkctl speakPrevious:nil];
     else if ([action isEqualToString:@"Speak move after"])
-        [self speakNext:nil];
+        [self.glkctl speakNext:nil];
     else if ([action isEqualToString:@"Speak status bar"])
-        [self speakStatus:nil];
+        [self.glkctl speakStatus:nil];
     else
         [super accessibilityPerformAction:action];
 }
@@ -2974,7 +2961,6 @@ willChangeSelectionFromCharacterRange:(NSRange)oldrange
 
 - (id)accessibilityAttributeValue:(NSString *)attribute {
     NSResponder *firstResponder = self.window.firstResponder;
-
     // NSLog(@"GlkTextBufferWindow: accessibilityAttributeValue: %@",attribute);
     if ([attribute isEqualToString:NSAccessibilityRoleAttribute]) {
         return NSAccessibilityUnknownRole;
@@ -3001,7 +2987,6 @@ willChangeSelectionFromCharacterRange:(NSRange)oldrange
     } else if ([attribute isEqualToString:NSAccessibilityChildrenAttribute]) {
         return @[ _textview ];
     }
-
     return [super accessibilityAttributeValue:attribute];
 }
 
@@ -3011,13 +2996,13 @@ willChangeSelectionFromCharacterRange:(NSRange)oldrange
 
 - (NSArray *)links {
     NSRange allText = NSMakeRange(0, textstorage.length);
-   if (moveRanges.count < 2)
+   if (_moveRanges.count < 2)
        return [self linksInRange:allText];
     NSMutableArray *links = [[NSMutableArray alloc] init];
 
-    for (NSValue *rangeVal in [moveRanges reverseObjectEnumerator])
+    for (NSValue *rangeVal in [_moveRanges reverseObjectEnumerator])
     {
-        // print some info
+        // Print some info
         [links addObjectsFromArray:[self linksInRange:rangeVal.rangeValue]];
         if (links.count > 15)
             break;

--- a/application/GlkTextBufferWindow.m
+++ b/application/GlkTextBufferWindow.m
@@ -2108,6 +2108,7 @@ replacementString:(id)repl {
 - (NSRange)textView:(NSTextView *)aTextView
 willChangeSelectionFromCharacterRange:(NSRange)oldrange
    toCharacterRange:(NSRange)newrange {
+           NSLog(@"willChangeSelectionFromCharacterRange: %@ toCharacterRange: %@", NSStringFromRange(oldrange), NSStringFromRange(newrange));
     if (line_request) {
         if (newrange.length == 0)
             if (newrange.location < fence)

--- a/application/GlkTextGridWindow.h
+++ b/application/GlkTextGridWindow.h
@@ -42,10 +42,11 @@
 @property BOOL hasNewText;
 
 - (BOOL)myMouseDown:(NSEvent *)theEvent;
-- (IBAction)speakStatus:(id)sender;
+
 - (BOOL)setLastMove;
 - (void)deferredGrabFocus:(id)sender;
 - (void)recalcBackground;
-- (void)speakMostRecent:(id)sender;
+- (void)speakStatus;
+- (void)speakMostRecent;
 
 @end

--- a/application/GlkTextGridWindow.m
+++ b/application/GlkTextGridWindow.m
@@ -1579,9 +1579,7 @@
     return _textview;
 }
 
-- (IBAction)speakStatus:(id)sender {
-    NSLog(@"GlkTextGridWindow %ld speakStatus:", self.name);
-    NSLog(@"\"%@\"", textstorage.string);
+- (void)speakStatus {
     if (self.glkctl.zmenu)
         [NSObject cancelPreviousPerformRequestsWithTarget:self.glkctl.zmenu];
     NSDictionary *announcementInfo = @{
@@ -1599,8 +1597,8 @@
     return hadNewText;
 }
 
-- (void)speakMostRecent:(id)sender {
-    [self speakStatus:nil];
+- (void)speakMostRecent {
+    [self speakStatus];
 }
 
 - (NSArray *)links {


### PR DESCRIPTION
Make the "speak previous move" actions work the same from any Glk window.

Also adds a couple of new custom rotors, one for previous moves and one for Glk windows.