### PR TITLE
[Bocfel] Fix exception handling

### DIFF
--- a/terps/bocfel/io.c
+++ b/terps/bocfel/io.c
@@ -319,26 +319,14 @@ bool zterp_io_close_memory(zterp_io *io, uint8_t **buf, long *n)
   return true;
 }
 
-/* Turn on “exception handling” for this I/O object. After calling this
- * function, all future I/O calls which return a bool will now instead
- * cause this function to return false in case of error. Simple usage:
- *
- * if(!zterp_io_try(io)) return ERROR;
- * // call I/O functions here
- *
- * This *only* affects boolean functions. Those which return non-boolean
- * values, such as zterp_io_write() and zterp_io_getc() are unaffected.
- * This may be inconsistent, at least for zterp_io_getc(), which can
- * return a failure condition, but non-boolean functions are not
- * currently used with exception handling, so it’s not relevant.
- */
-bool zterp_io_try(zterp_io *io)
+void zterp_io_set_exception_mode(zterp_io *io, bool mode)
 {
-  io->exception_mode = true;
+  io->exception_mode = mode;
+}
 
-  if(setjmp(io->exception) != 0) return false;
-
-  return true;
+jmp_buf *zterp_io_get_exception(zterp_io *io)
+{
+  return &io->exception;
 }
 
 static bool wrap(zterp_io *io, bool b)

--- a/terps/bocfel/stack.c
+++ b/terps/bocfel/stack.c
@@ -747,8 +747,10 @@ static void write_chunk(zterp_io *io, char (*(*writefunc)(zterp_io *))[5])
 bool save_quetzal(zterp_io *savefile, bool is_meta, bool store_history)
 {
   long file_size;
+  bool ok;
 
-  if(!zterp_io_try(savefile)) return false;
+  zterp_io_try(savefile, ok);
+  if (!ok) return false;
 
   zterp_io_write_exact(savefile, "FORM", 4);
   zterp_io_write32(savefile, 0); /* to be filled in */


### PR DESCRIPTION
I made a boneheaded mistake which made its way into Bocfel 1.2 (and 1.2.1).  In short, if there is an error writing a save file, there'll be undefined behavior.  It's not critical, though, since there should only be a write error if there's an issue like a full disk or I/O error.

I think you're probably the only active user of Bocfel outside of Gargoyle, and since you're doing regular releases, I'm providing a fix here until the next Bocfel release.  Again, this isn't something that anybody is likely to run into, but still better to have it fixed.