### PR TITLE
Remove hard-coded sizes from snprintf

### DIFF
--- a/terps/plus/graphics.c
+++ b/terps/plus/graphics.c
@@ -50,7 +50,7 @@ void DrawBlack(void)
 
 char *ShortNameFromType(char type, int index) {
     char buf[5];
-    int n = snprintf(buf, 5, "%c0%02d", type, index);
+    int n = snprintf(buf, sizeof buf, "%c0%02d", type, index);
     if (n < 0)
         return NULL;
     size_t len = strlen(buf) + 1;
@@ -184,7 +184,7 @@ void DrawItemImage(int item) {
     LastImgIndex = item;
     char buf[1024];
 
-        int n = snprintf( buf, 5, "B0%02d", item);
+        int n = snprintf( buf, sizeof buf, "B0%02d", item);
         if (n < 0)
             return;
 
@@ -198,7 +198,7 @@ int DrawCloseup(int img) {
     LastImgIndex = img;
     char buf[1024];
 
-    int n = snprintf( buf, 5, "S0%02d", img);
+    int n = snprintf( buf, sizeof buf, "S0%02d", img);
     if (n < 0)
         return 0;
 
@@ -224,7 +224,7 @@ int DrawRoomImage(int roomimg) {
     LastImgIndex = roomimg;
 
     char buf[5];
-    int n = snprintf( buf, 5, "R0%02d", roomimg);
+    int n = snprintf( buf, sizeof buf, "R0%02d", roomimg);
     if (n < 0)
         return 0;
     buf[4] = 0;

--- a/terps/plus/loaddatabase.c
+++ b/terps/plus/loaddatabase.c
@@ -778,7 +778,7 @@ static int SetGame(const char *id_string, size_t length) {
 int FindAndAddImageFile(char *shortname, struct imgrec *rec) {
     int result = 0;
     char filename[2048];
-    int n = snprintf(filename, DirPathLength + 9, "%s%s.PAK", DirPath, shortname);
+    int n = snprintf(filename, filename, "%s%s.PAK", DirPath, shortname);
     if (n > 0) {
         FILE *infile=fopen(filename,"rb");
         if (infile) {

--- a/terps/plus/plusmain.c
+++ b/terps/plus/plusmain.c
@@ -300,7 +300,7 @@ void Updates(event_t ev)
         OpenGraphicsWindow();
         if (AnimationRunning && LastAnimationBackground) {
             char buf[5];
-            snprintf(buf, 5, "S0%02d", LastAnimationBackground);
+            snprintf(buf, sizeof buf, "S0%02d", LastAnimationBackground);
             DrawImageWithName(buf);
         } else {
             SetBit(DRAWBIT);

--- a/terps/scott/saga/pcdraw.c
+++ b/terps/scott/saga/pcdraw.c
@@ -30,7 +30,7 @@ uint8_t *FindImageFile(const char *shortname, size_t *datasize) {
     uint8_t *data = NULL;
     char filename[2048];
     size_t namelength = strlen(DirPath) + strlen(shortname) + 5;
-    int n = snprintf(filename, namelength, "%s%s.PAK", DirPath, shortname);
+    int n = snprintf(filename, sizeof filename, "%s%s.PAK", DirPath, shortname);
     if (n > 0) {
         FILE *infile=fopen(filename,"rb");
         if (infile) {

--- a/terps/scott/saga/woz2nib.c
+++ b/terps/scott/saga/woz2nib.c
@@ -377,7 +377,7 @@ uint8_t *woz2nib(uint8_t *ptr, size_t *len) {
     char *bitstring = NULL;
 
     for (int track = 0; track < nr_tracks; track++) {
-        snprintf(t_hex, 3, "%02x", track);
+        snprintf(t_hex, sizeof t_hex, "%02x", track);
         debug_print("Track $%s\n", t_hex);
         trks_index = tmap[track];
         if (trks_index == 0xff) { // empty track


### PR DESCRIPTION
I was looking over the patches in more detail, and noticed that snprintf() is being called with a hard-coded size.  This switches snprintf() calls to use sizeof to determine the target size.

In two places, there is a 1024-byte buffer, but the size "5" is hard-coded.  I think the "5" was just accidentally used since previous buffer sizes _are_ 5.

And in loaddatabase.cpp, the size was `DirPathLength + 9` for one of the calls, but should just be the target size of the buffer (to ensure no overflow happens).

Finally, in pcdraw.c, `namelength` was being passed instead of the size of the target buffer, so I updated that.