### PR TITLE
Don't allow Alan to call system()

### DIFF
--- a/terps/alan2/exe.c
+++ b/terps/alan2/exe.c
@@ -121,7 +121,9 @@ void sys(fpos, len)
 
   getstr(fpos, len);            /* Returns address to string on stack */
   command = (char *)pop();
+#if 0
   int tmp = system(command);
+#endif
   free(command);
 }
 

--- a/terps/alan3/exe.c
+++ b/terps/alan3/exe.c
@@ -146,8 +146,10 @@ void sys(Aword fpos, Aword len)
     char *command;
 
     command = getStringFromFile(fpos, len);
+#if 0
     if (system(command) == -1)
         /* Ignore errors */;
+#endif
     deallocate(command);
 }
 


### PR DESCRIPTION
While going over the Alan2 source, I discovered that it can, apparently, call the `system()` function with an arbitrary string from the game.  While I'm not entirely sure the mechanism behind it (looks like there's a SYSTEM instruction, so it would be trivial for a game to call), I can't see any legitimate reason to allow it to happen. There are no circumstances I can think of where it makes _any_ sense for a game to be able to run a command on a user's machine. It's a massive security risk.

This change simply drops the call to `system()`.