### PR TITLE
Add support for Arthur: The Quest for Excalibur

### DIFF
--- a/Spatterlight.xcodeproj/project.pbxproj
+++ b/Spatterlight.xcodeproj/project.pbxproj
@@ -585,6 +585,7 @@
 		C354AA74274D096500C8D01D /* grail.blorb in Resources */ = {isa = PBXBuildFile; fileRef = C354AA73274D096500C8D01D /* grail.blorb */; };
 		C354C6DD275791C000EBB449 /* t23run.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C354C6DC275791C000EBB449 /* t23run.cpp */; };
 		C354C6DF275791ED00EBB449 /* t2indlg.c in Sources */ = {isa = PBXBuildFile; fileRef = C354C6DE275791ED00EBB449 /* t2indlg.c */; };
+		C359499E2D2C39EB008F6551 /* InfocomV6MenuHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = C359499D2D2C39EB008F6551 /* InfocomV6MenuHandler.m */; };
 		C35C54042676613800294FE7 /* NSFont+Categories.m in Sources */ = {isa = PBXBuildFile; fileRef = C35C54032676613800294FE7 /* NSFont+Categories.m */; };
 		C35CB31E285DD7BF00601E97 /* animations.c in Sources */ = {isa = PBXBuildFile; fileRef = C35CB31D285DD7BF00601E97 /* animations.c */; };
 		C35D520826F24142002E2F59 /* FolderAccess.m in Sources */ = {isa = PBXBuildFile; fileRef = C35D520726F24142002E2F59 /* FolderAccess.m */; };
@@ -615,6 +616,8 @@
 		C37EC5A8284807750084B841 /* plus in Copy Interpreter Files */ = {isa = PBXBuildFile; fileRef = C37EC5992847AA040084B841 /* plus */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		C381012A1EDA297E00B87B68 /* GlkController.m in Sources */ = {isa = PBXBuildFile; fileRef = C38101291EDA297E00B87B68 /* GlkController.m */; };
 		C3824B4C2CAD821F00D58EFC /* libreadwoz.dylib in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C3ED63132C6E0E64000F90A8 /* libreadwoz.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		C3824B7A2CAEF0A800D58EFC /* arthur.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C3824B792CAEF0A800D58EFC /* arthur.cpp */; };
+		C3824B7E2CAEF0F200D58EFC /* v6_shared.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C3824B7D2CAEF0F200D58EFC /* v6_shared.cpp */; };
 		C3836ED82789B569004B5061 /* seasofblood.c in Sources */ = {isa = PBXBuildFile; fileRef = C3836ED52789B553004B5061 /* seasofblood.c */; };
 		C384A6722C6EAEC30081FC50 /* journey.hpp in Sources */ = {isa = PBXBuildFile; fileRef = C3ED63602C6E1293000F90A8 /* journey.hpp */; };
 		C384A6742C6EAEDF0081FC50 /* extract_apple_2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C3ED635E2C6E1193000F90A8 /* extract_apple_2.cpp */; };
@@ -2846,6 +2849,8 @@
 		C354AA73274D096500C8D01D /* grail.blorb */ = {isa = PBXFileReference; lastKnownFileType = file; path = grail.blorb; sourceTree = "<group>"; };
 		C354C6DC275791C000EBB449 /* t23run.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = t23run.cpp; path = glk/t23run.cpp; sourceTree = "<group>"; };
 		C354C6DE275791ED00EBB449 /* t2indlg.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = t2indlg.c; path = glk/t2indlg.c; sourceTree = "<group>"; };
+		C359499C2D2C39EB008F6551 /* InfocomV6MenuHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InfocomV6MenuHandler.h; sourceTree = "<group>"; };
+		C359499D2D2C39EB008F6551 /* InfocomV6MenuHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = InfocomV6MenuHandler.m; sourceTree = "<group>"; };
 		C35978C325DA14A6004B1448 /* iFictionPreviewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = iFictionPreviewController.h; sourceTree = "<group>"; };
 		C35978C425DA14A6004B1448 /* iFictionPreviewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = iFictionPreviewController.m; sourceTree = "<group>"; };
 		C35C54022676613800294FE7 /* NSFont+Categories.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSFont+Categories.h"; sourceTree = "<group>"; };
@@ -2889,6 +2894,10 @@
 		C37EC5992847AA040084B841 /* plus */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = plus; sourceTree = BUILT_PRODUCTS_DIR; };
 		C37EC5A62847CD620084B841 /* sagaplus.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sagaplus.c; sourceTree = "<group>"; };
 		C38101291EDA297E00B87B68 /* GlkController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GlkController.m; sourceTree = "<group>"; };
+		C3824B782CAEF0A800D58EFC /* arthur.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = arthur.hpp; sourceTree = "<group>"; };
+		C3824B792CAEF0A800D58EFC /* arthur.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = arthur.cpp; sourceTree = "<group>"; };
+		C3824B7C2CAEF0F200D58EFC /* v6_shared.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = v6_shared.hpp; sourceTree = "<group>"; };
+		C3824B7D2CAEF0F200D58EFC /* v6_shared.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = v6_shared.cpp; sourceTree = "<group>"; };
 		C3836ED42789B553004B5061 /* seasofblood.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = seasofblood.h; sourceTree = "<group>"; usesTabs = 0; };
 		C3836ED52789B553004B5061 /* seasofblood.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = seasofblood.c; sourceTree = "<group>"; usesTabs = 0; };
 		C384A67A2C6EAF770081FC50 /* decompress_amiga.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = decompress_amiga.hpp; sourceTree = "<group>"; };
@@ -5386,6 +5395,8 @@
 				C3F1078C259256AC00C9EC82 /* BureaucracyForm.m */,
 				C384A68C2C6F480B0081FC50 /* JourneyMenuHandler.h */,
 				C384A68D2C6F480C0081FC50 /* JourneyMenuHandler.m */,
+				C359499C2D2C39EB008F6551 /* InfocomV6MenuHandler.h */,
+				C359499D2D2C39EB008F6551 /* InfocomV6MenuHandler.m */,
 			);
 			path = "VoiceOver menu detection";
 			sourceTree = "<group>";
@@ -5867,8 +5878,12 @@
 			isa = PBXGroup;
 			children = (
 				C3ED635D2C6E1193000F90A8 /* v6_image.h */,
+				C3824B782CAEF0A800D58EFC /* arthur.hpp */,
+				C3824B792CAEF0A800D58EFC /* arthur.cpp */,
 				C3ED63602C6E1293000F90A8 /* journey.hpp */,
 				C3ED635F2C6E1293000F90A8 /* journey.cpp */,
+				C3824B7C2CAEF0F200D58EFC /* v6_shared.hpp */,
+				C3824B7D2CAEF0F200D58EFC /* v6_shared.cpp */,
 				C3ED63542C6E1192000F90A8 /* entrypoints.hpp */,
 				C3ED63552C6E1192000F90A8 /* entrypoints.cpp */,
 				C3ED63502C6E1192000F90A8 /* extract_apple_2.h */,
@@ -7099,10 +7114,12 @@
 				6DB774C02458B9B300EDC671 /* blorb.cpp in Sources */,
 				C384A67E2C6EAF780081FC50 /* decompress_vga.cpp in Sources */,
 				6DB774C12458B9B300EDC671 /* branch.cpp in Sources */,
+				C3824B7A2CAEF0A800D58EFC /* arthur.cpp in Sources */,
 				6DB774C22458B9B300EDC671 /* dict.cpp in Sources */,
 				6DB774C32458B9B300EDC671 /* glkstart.cpp in Sources */,
 				6DB774C62458B9B300EDC671 /* mathop.cpp in Sources */,
 				C3FB3287269F5BEE00A1B09C /* stash.cpp in Sources */,
+				C3824B7E2CAEF0F200D58EFC /* v6_shared.cpp in Sources */,
 				6DB774C72458B9B300EDC671 /* memory.cpp in Sources */,
 				C319329D27E407700054FE2C /* spatterlight-autosave.mm in Sources */,
 				C30C57D72C68C31900C2AAAF /* options.cpp in Sources */,
@@ -7287,6 +7304,7 @@
 				6DC520AA23BAD54B0004923A /* Game.m in Sources */,
 				6DD7679C23E45FB7003B605C /* ThemeArrayController.m in Sources */,
 				C3AD648F261769DB008614C5 /* MarginImage.m in Sources */,
+				C359499E2D2C39EB008F6551 /* InfocomV6MenuHandler.m in Sources */,
 				C3853E5F29676561002D4A27 /* SplitViewController.m in Sources */,
 				C3AD63D42617648D008614C5 /* MyAttachmentCell.m in Sources */,
 				C34E570F2CF3941200A8DC2B /* OpenGameOperation.m in Sources */,

--- a/application/GlkController.h
+++ b/application/GlkController.h
@@ -11,7 +11,7 @@
 
 #import <AppKit/AppKit.h>
 
-@class Game, Theme, GlkEvent, GlkWindow, ZMenu, BureaucracyForm, GlkTextGridWindow, GlkSoundChannel, SoundHandler, ImageHandler, RotorHandler, CommandScriptHandler, CoverImageHandler, GlkController;
+@class Game, Theme, GlkEvent, GlkWindow, ZMenu, BureaucracyForm, GlkTextGridWindow, GlkSoundChannel, SoundHandler, ImageHandler, RotorHandler, CommandScriptHandler, CoverImageHandler, GlkController, InfocomV6MenuHandler;
 
 #define MAXWIN 64
 
@@ -190,6 +190,7 @@ typedef enum kGameIdentity : NSUInteger {
 @property NSString *pendingSaveFilePath;
 
 @property CoverImageHandler *coverController;
+@property (nonatomic) InfocomV6MenuHandler *infocomV6MenuHandler;
 
 
 - (void)runTerp:(NSString *)terpname
@@ -236,5 +237,7 @@ typedef enum kGameIdentity : NSUInteger {
 
 - (void)setBorderColor:(NSColor *)color;
 - (void)terminateTask;
+
+- (BOOL)showingInfocomV6Menu;
 
 @end

--- a/application/GlkEvent.m
+++ b/application/GlkEvent.m
@@ -266,9 +266,10 @@ unsigned chartokeycode(unsigned ch) {
         settings->slowdraw = (int)theme.slowDrawing;
         settings->flicker = (int)theme.flicker;
         settings->zmachine_terp = (int)theme.zMachineTerp;
+        settings->zmachine_terp = (int)theme.zMachineNoErrWin;
         settings->z6_graphics = (int)theme.z6GraphicsType;
         settings->z6_colorize = (int)theme.z6Colorize1Bit;
-        settings->z6_sim_16_cols = (int)theme.z6Simulate16Color;
+        settings->zmachine_no_err_win = (int)theme.zMachineNoErrWin;
 
         settings->force_arrange = _forced;
 

--- a/application/GlkTextBufferWindow/GlkTextBufferWindow.h
+++ b/application/GlkTextBufferWindow/GlkTextBufferWindow.h
@@ -52,9 +52,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)padWithNewlines:(NSUInteger)lines;
 
 - (void)scrollWheelchanged:(NSEvent *)event;
+- (void)updateMarginImagesWithXScale:(CGFloat)xscale yScale:(CGFloat)yscale;
 
+// Only used by JourneyMenuHandler
 - (NSString *)lastMoveString;
 
+- (void)movesRangesFromV6Menu:(NSArray<NSString *> *)menuStrings;
+
+// Only used by JourneyMenuHandler
 @property NSInteger lastNewTextOnTurn;
 
 @property (NS_NONATOMIC_IOSONLY, readonly) NSRange editableRange;

--- a/application/GlkWindow.h
+++ b/application/GlkWindow.h
@@ -87,6 +87,7 @@ typedef NS_ENUM(int32_t, kSaveTextFormatType) {
 - (NSMutableAttributedString *)applyReverseOnly:(NSMutableAttributedString *)attStr;
 
 - (NSMutableDictionary *)reversedAttributes:(NSMutableDictionary *)dict background:(NSColor *)backCol;
+- (NSMutableDictionary *)getCurrentAttributesForStyle:(NSUInteger)stylevalue;
 
 - (void)fillRects:(struct fillrect *)rects count:(NSInteger)n;
 - (void)drawImage:(NSImage *)buf

--- a/application/Images/ImageHandler.m
+++ b/application/Images/ImageHandler.m
@@ -279,7 +279,6 @@
         // Hack for placeholder images, which only have dimensions, no content.
         NSInteger width = ((const unsigned char *)(_resources[@(resno)].data.bytes))[3] + ((const unsigned char *)(_resources[@(resno)].data.bytes))[2] * 0x100;
         NSInteger height = ((const unsigned char *)(_resources[@(resno)].data.bytes))[7] + ((const unsigned char *)(_resources[@(resno)].data.bytes))[6] * 0x100;
-        NSLog(@"handleLoadImageNumber: Found placeholder image %ld with width %ld and height %ld", resno, width, height);
 
         // No size must be 0, or both will be, so we add a "rounding error"
         _lastimage = [[NSImage alloc] initWithSize:NSMakeSize(width + 0.01, height + 0.01)];
@@ -331,6 +330,14 @@
         return;
 
     [_imageCache removeObjectForKey:@(resno)];
+    ImageResource *resource = _resources[@(resno)];
+    NSError *error = nil;
+    if (![Blorb isBlorbURL:resource.imageFile.URL]) {
+        [[NSFileManager defaultManager] removeItemAtURL:resource.imageFile.URL error:&error];
+        if (error) {
+            NSLog(@"purgeImage: %@", error);
+        }
+    }
     _resources[@(resno)] = nil;
 
     if (!replacementPath) {

--- a/application/Preferences/BuiltInThemes.m
+++ b/application/Preferences/BuiltInThemes.m
@@ -287,7 +287,7 @@
     if (exists && !force)
         return classicTheme;
 
-    classicTheme.bZAdjustment = 0;
+    classicTheme.bZAdjustment = 4;
 
     classicTheme.dashes = NO;
     classicTheme.defaultRows = 50;

--- a/application/Preferences/Preferences.h
+++ b/application/Preferences/Preferences.h
@@ -164,6 +164,7 @@ typedef NS_ENUM(NSUInteger, kModeType) {
 @property (strong) IBOutlet NSButton *hardDarkCheckbox;
 @property (strong) IBOutlet NSButton *hardLightCheckbox;
 @property (strong) IBOutlet NSButton *scottAdamsFlickerCheckbox;
+@property (strong) IBOutlet NSButton *zMachineNoErrWinCheckbox;
 
 @property DummyTextView *dummyTextView;
 

--- a/application/Preferences/Preferences.m
+++ b/application/Preferences/Preferences.m
@@ -690,7 +690,8 @@ NSString *fontToString(NSFont *font) {
 
     [_z6GraphicsPopup selectItemWithTag:theme.z6GraphicsType];
     _z6ColorizeCheckBox.state = theme.z6Colorize1Bit ? NSOnState : NSOffState;
-    _z6Sim16ColoursCheckBox.state = theme.z6Simulate16Color ? NSOnState : NSOffState;
+
+    _zMachineNoErrWinCheckbox.state = theme.zMachineNoErrWin ? NSOnState : NSOffState;
 
     _btnSmoothScroll.state = theme.smoothScroll;
     _btnAutosave.state = theme.autosave;
@@ -1922,6 +1923,10 @@ textShouldEndEditing:(NSText *)fieldEditor {
     [self changeBooleanAttribute:@"quoteBox" fromButton:sender];
 }
 
+- (IBAction)changeNoErrWinCheckBox:(id)sender {
+    [self changeBooleanAttribute:@"zMachineNoErrWin" fromButton:sender];
+}
+
 #pragma mark Z Machine version 6 stuff
 
 - (IBAction)changez6GraphicsMenu:(id)sender {
@@ -1930,10 +1935,6 @@ textShouldEndEditing:(NSText *)fieldEditor {
 
 - (IBAction)changez6ColorizeCheckBox:(id)sender {
     [self changeBooleanAttribute:@"z6Colorize1Bit" fromButton:sender];
-}
-
-- (IBAction)changez6sim16ColorCheckBox:(id)sender {
-    [self changeBooleanAttribute:@"z6Simulate16Color" fromButton:sender];
 }
 
 #pragma mark Scott Adams menu

--- a/application/RotorHandler.m
+++ b/application/RotorHandler.m
@@ -495,7 +495,7 @@
         NSString *string = strings[currentItemIndex];
         string = [string stringByTrimmingCharactersInSet:charset];
         // Strip command line if the speak command setting is off
-        if (!_glkctl.theme.vOSpeakCommand) {
+        if (!_glkctl.theme.vOSpeakCommand && !_glkctl.showingInfocomV6Menu) {
             NSUInteger promptIndex = searchResult.targetRange.location;
             if (promptIndex != 0)
                 promptIndex--;

--- a/application/VoiceOver menu detection/InfocomV6MenuHandler.h
+++ b/application/VoiceOver menu detection/InfocomV6MenuHandler.h
@@ -1,0 +1,37 @@
+//
+//  InfocomV6MenuHandler.h
+//  Spatterlight
+//
+//  Created by Administrator on 2025-01-06.
+//
+
+#import <Foundation/Foundation.h>
+
+#include "glkimp.h"
+
+@class GlkController;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface InfocomV6MenuHandler : NSObject
+
+- (instancetype)initWithDelegate:(GlkController *)delegate;
+
+- (void)handleMenuItemOfType:(InfocomV6MenuType)type index:(NSUInteger)index total:(NSUInteger)total text:(char *)buf length:(NSUInteger)len;
+//- (void)describeMenu;
+
+- (NSString *)menuLineStringWithTitle:(BOOL)useTitle index:(BOOL)useIndex total:(BOOL)useTotal instructions:(BOOL)useInstructions;
+- (NSString *)constructMenuInstructionString;
+- (void)updateMoveRanges:(GlkTextBufferWindow *)window;
+
+@property (weak) GlkController *delegate;
+
+@property NSMutableArray<NSString *> *menuItems;
+@property NSUInteger numberOfItems;
+@property NSString *title;
+@property NSUInteger selectedLine;
+@property BOOL hasDescribedMenu;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/application/VoiceOver menu detection/InfocomV6MenuHandler.m
+++ b/application/VoiceOver menu detection/InfocomV6MenuHandler.m
@@ -1,0 +1,178 @@
+//
+//  InfocomV6MenuHandler.m
+//  Spatterlight
+//
+//  Created by Administrator on 2025-01-06.
+//
+
+#import "GlkController.h"
+#import "ZMenu.h"
+#import "GlkWindow.h"
+#import "GlkTextBufferWindow.h"
+
+
+#import "InfocomV6MenuHandler.h"
+
+@interface InfocomV6MenuHandler () {
+    InfocomV6MenuType hintDepth;
+    BOOL hasUpdatedMoveRanges;
+}
+@end
+
+@implementation InfocomV6MenuHandler
+
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
+
+- (instancetype)initWithDelegate:(GlkController *)delegate {
+    self = [super init];
+    if (self) {
+        self.delegate = delegate;
+        hintDepth = kV6MenuNone;
+    }
+    return self;
+}
+
+- (void)handleMenuItemOfType:(InfocomV6MenuType)type index:(NSUInteger)index total:(NSUInteger)total text:(char *)buf length:(NSUInteger)len {
+
+    _selectedLine = index;
+    hasUpdatedMoveRanges = NO;
+
+    if (type == kV6MenuSelectionChanged) {
+        _delegate.zmenu.haveSpokenMenu = YES;
+        return;
+    } else if (type == kV6MenuExited) {
+        _delegate.zmenu.haveSpokenMenu = NO;
+        _delegate.infocomV6MenuHandler = nil;
+        return;
+    }
+
+    if (_menuItems == nil) {
+        _menuItems = [NSMutableArray new];
+    }
+
+    NSString *str;
+    if (len > 0) {
+        unichar cstring[len];
+        for (NSUInteger i = 0; i < len; i++) {
+            cstring[i] = (unichar)buf[i];
+        }
+        str = [NSString stringWithCharacters:cstring length:len];
+    }
+
+    if (type == kV6MenuTitle) {
+        _title = str;
+        hintDepth = (InfocomV6MenuType)total;
+    } else {
+        hintDepth = type;
+        if (total > 0) {
+            _numberOfItems = total;
+        } else {
+            _numberOfItems = _menuItems.count + 1;
+        }
+        if (str.length) {
+            if (type == kV6MenuTypeHint &&
+                [str isEqualToString:@"[No more hints.]\n"]) {
+                str = [NSString stringWithFormat:@"%@\n[No more hints.]", _menuItems.lastObject];
+                [_menuItems removeLastObject];
+            }
+            [_menuItems addObject:str];
+        }
+    }
+}
+
+- (NSString *)constructMenuInstructionString {
+    NSString *instructionString = @"";
+    if (hintDepth != kV6MenuTypeHint) {
+        instructionString = @"N for next item. P for previous item. ";
+    }
+
+    if (hintDepth != kV6MenuTypeTopic) {
+        instructionString = [instructionString stringByAppendingString:@"M for hint menu. "];
+    }
+
+    if (hintDepth == kV6MenuTypeHint) {
+        if (_selectedLine < _numberOfItems - 1 || _menuItems.count == 0) {
+            instructionString = [instructionString stringByAppendingString:@"Return for a hint. "];
+        }
+    } else {
+        instructionString = [instructionString stringByAppendingString:@"Return for hints. "];
+    }
+
+    instructionString = [instructionString stringByAppendingString:@"Q to resume story. "];
+
+    if (hintDepth == kV6MenuTypeHint && _numberOfItems > 1 && _menuItems.count > 1) {
+        instructionString = [instructionString stringByAppendingString:@"You can review the hints by stepping through moves."];
+    }
+
+    return instructionString;
+}
+
+- (void)updateMoveRanges:(GlkTextBufferWindow *)window {
+    if (hintDepth == kV6MenuTypeHint && !hasUpdatedMoveRanges) {
+        hasUpdatedMoveRanges = YES;
+        [window movesRangesFromV6Menu:_menuItems];
+    }
+}
+
+- (NSString *)menuLineStringWithTitle:(BOOL)useTitle index:(BOOL)useIndex total:(BOOL)useTotal instructions:(BOOL)useInstructions {
+
+    _delegate.zmenu.haveSpokenMenu = YES;
+    NSString *menuLineString = @"";
+
+    if (_menuItems.count) {
+        NSLog(@"_selectedLine: %ld", _selectedLine);
+        if (_selectedLine >= _menuItems.count) {
+            _selectedLine = _menuItems.count - 1;
+        }
+        menuLineString = [menuLineString stringByAppendingString:_menuItems[_selectedLine]];
+    }
+
+    NSString *menuItemString = @"Menu item";
+    NSString *weAreInAMenuString = @"We are in a menu";
+
+    if (hintDepth == kV6MenuTypeHint) {
+        menuItemString = @"Hint";
+        weAreInAMenuString = @"Showing hints for";
+    }
+
+    if (useIndex) {
+
+        NSString *indexString;
+
+        if (hintDepth == kV6MenuTypeHint && _menuItems.count == 0) {
+            indexString = [NSString stringWithFormat:@"%ld hints available", _numberOfItems];
+        } else {
+            if (_selectedLine >= _numberOfItems) {
+                _selectedLine = _numberOfItems - 1;
+            }
+            indexString = [NSString stringWithFormat:@".\n%@ %ld", menuItemString, _selectedLine + 1];
+            if (useTotal) {
+                indexString = [indexString stringByAppendingString:
+                               [NSString stringWithFormat:@" of %ld", _numberOfItems]];
+            }
+        }
+
+        indexString = [indexString stringByAppendingString:@".\n"];
+        menuLineString = [menuLineString stringByAppendingString:indexString];
+    }
+
+    if (useInstructions) {
+        menuLineString = [menuLineString stringByAppendingString:[self constructMenuInstructionString]];
+    }
+
+    if (useTitle) {
+        NSString *titleString = _title;
+        if (titleString.length) {
+            titleString = [NSString stringWithFormat:@"%@, \"%@.\"\n", weAreInAMenuString, titleString];
+        } else {
+            titleString = @"We are in a menu.\n";
+        }
+        menuLineString = [titleString stringByAppendingString:menuLineString];
+    }
+
+    return menuLineString;
+}
+
+@end

--- a/application/VoiceOver menu detection/JourneyMenuHandler.m
+++ b/application/VoiceOver menu detection/JourneyMenuHandler.m
@@ -607,7 +607,7 @@ errorDescription:(NSString * __autoreleasing *)error
         return;
     }
 
-    unichar cstring[20];
+    unichar cstring[len];
     for (NSUInteger i = 0; i < len; i++) {
         cstring[i] = (unichar)buf[i];
     }
@@ -782,7 +782,7 @@ errorDescription:(NSString * __autoreleasing *)error
             }
             break;
         default:
-            NSLog(@"Error!");
+            NSLog(@"handleMenuItemOfType: Unhandled switch case!");
             break;
     }
 }

--- a/application/VoiceOver menu detection/ZMenu.h
+++ b/application/VoiceOver menu detection/ZMenu.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)speakSelectedLine;
 - (void)deferredSpeakSelectedLine:(id)sender;
 
-- (NSString *)menuLineStringWithTitle:(BOOL)title Index:(BOOL)index total:(BOOL)total instructions:(BOOL)instructions;
+- (NSString *)menuLineStringWithTitle:(BOOL)title index:(BOOL)index total:(BOOL)total instructions:(BOOL)instructions;
 
 @property (NS_NONATOMIC_IOSONLY, readonly) NSUInteger findSelectedLine;
 

--- a/coredata/GlkStyle.m
+++ b/coredata/GlkStyle.m
@@ -136,6 +136,9 @@
 
     NSMutableDictionary *attributes = [self.attributeDict mutableCopy];
 
+    if (hints.count == 0)
+        return attributes;
+
     NSFont *font = attributes[NSFontAttributeName];
     NSFontManager *fontmgr = [NSFontManager sharedFontManager];
 

--- a/coredata/Theme.h
+++ b/coredata/Theme.h
@@ -118,6 +118,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) int32_t winSpacingY;
 @property (nonatomic) int32_t zMachineTerp;
 @property (nullable, nonatomic, copy) NSString *zMachineLetter;
+@property (nonatomic) BOOL zMachineNoErrWin;
 
 @property (nonatomic) double vOHackDelay;
 @property (nonatomic) BOOL vODelayOn;
@@ -127,7 +128,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) kZ6GraphicsPrefsType z6GraphicsType;
 @property (nonatomic) BOOL z6Colorize1Bit;
-@property (nonatomic) BOOL z6Simulate16Color;
 
 @property (nullable, nonatomic, retain) GlkStyle *bufAlert;
 @property (nullable, nonatomic, retain) GlkStyle *bufBlock;

--- a/coredata/Theme.m
+++ b/coredata/Theme.m
@@ -74,6 +74,7 @@
 @dynamic winSpacingY;
 @dynamic zMachineTerp;
 @dynamic zMachineLetter;
+@dynamic zMachineNoErrWin;
 @dynamic vOHackDelay;
 @dynamic vODelayOn;
 @dynamic vOSpeakCommand;
@@ -81,7 +82,6 @@
 @dynamic vOSpeakMenu;
 @dynamic z6GraphicsType;
 @dynamic z6Colorize1Bit;
-@dynamic z6Simulate16Color;
 @dynamic bufAlert;
 @dynamic bufBlock;
 @dynamic bufEmph;
@@ -161,13 +161,12 @@
         //NSLog(@"Setting my %@ to a clone of the %@ of %@", keyName, keyName, theme.name);
         [self setValue:clonedStyle forKey:keyName];
         if ([clonedStyle valueForKey:keyName] != self)
-            NSLog(@"Error! Reciprocal relationship did not work as expected");
+            NSLog(@"copyAttributesFrom error! Reciprocal relationship did not work as expected");
         keyName = gGridStyleNames[i];
         clonedStyle = [(GlkStyle * )[theme valueForKey:keyName] clone];
-//        NSLog(@"Setting my %@ to a clone of the %@ of %@", keyName, keyName, theme.name);
         [self setValue:clonedStyle forKey:keyName];
         if ([clonedStyle valueForKey:keyName] != self)
-            NSLog(@"Error! Reciprocal relationship did not work as expected");
+            NSLog(@"copyAttributesFrom error! Reciprocal relationship did not work as expected");
 	}
 }
 

--- a/glkimp/fileref.m
+++ b/glkimp/fileref.m
@@ -127,7 +127,7 @@ void getautosavedir(char *file)
 
 void gettempdir(void)
 {
-    /* if we have already set an autosave dir path, we return right away */
+    /* if we have already set a temp dir path, we return right away */
     if (strcmp(tempdir, "")) {
         return;
     }

--- a/glkimp/glkimp.h
+++ b/glkimp/glkimp.h
@@ -58,7 +58,7 @@ extern int gli_flicker;
 extern int gli_zmachine_terp;
 extern int gli_z6_graphics;
 extern int gli_z6_colorize;
-extern int gli_z6_sim_16_cols;
+extern int gli_zmachine_no_err_win;
 
 
 extern glui32 tagcounter;
@@ -118,6 +118,11 @@ void win_cancelmouse(int name);
 //  against the Glk spec, to change the background on-the-fly
 // of buffer and grid windows.
 void win_setbgnd(int name, glui32 color);
+
+// Redraw a buffer window with current styles,
+// against the Glk spec.
+void win_refresh(int name, float xscale, float yscale);
+
 void win_clear(int name);
 void win_moveto(int name, int x, int y);
 
@@ -178,7 +183,17 @@ typedef enum JourneyMenuType {
     kJMenuTypeDeleteAll
 } JourneyMenuType;
 
-void win_menuitem(JourneyMenuType type, glui32 column, glui32 line, glui32 stopflag, char *str, int len);
+typedef enum InfocomV6MenuType {
+    kV6MenuNone,
+    kV6MenuTypeTopic,
+    kV6MenuTypeQuestion,
+    kV6MenuTypeHint,
+    kV6MenuSelectionChanged,
+    kV6MenuTitle,
+    kV6MenuExited,
+} InfocomV6MenuType;
+
+void win_menuitem(int type, glui32 column, glui32 line, glui32 stopflag, char *str, int len);
 
 void gli_close_all_file_streams(void);
 

--- a/glkimp/protocol.h
+++ b/glkimp/protocol.h
@@ -49,9 +49,9 @@ struct settings_struct
     int slowdraw;
     int flicker;
     int zmachine_terp;
+    int zmachine_no_err_win;
     int z6_graphics;
     int z6_colorize;
-    int z6_sim_16_cols;
     int determinism;
     int error_handling;
     int force_arrange;
@@ -83,6 +83,7 @@ enum
     CLEARHINT,
     STYLEMEASURE,
     SETBGND,
+    REFRESH,
     SETTITLE,
     AUTOSAVE,
     RESET,

--- a/glkimp/window.c
+++ b/glkimp/window.c
@@ -714,8 +714,9 @@ void glk_set_window(window_t *win)
 {
     if (!win)
         glk_stream_set_current(NULL);
-    else
+    else {
         glk_stream_set_current(win->str);
+    }
 }
 
 void gli_windows_unechostream(stream_t *str)
@@ -1005,6 +1006,8 @@ void glk_request_line_event(window_t *win, char *buf, glui32 maxlen, glui32 init
         gli_strict_warning("request_line_event: invalid ref");
         return;
     }
+
+    fprintf(stderr, "glk_request_line_event peer %d\n", win->peer);
 
     if (win->char_request || win->line_request)
     {
@@ -1302,22 +1305,8 @@ void glk_window_clear(window_t *win)
         gli_strict_warning("window_clear: window has pending line request");
         return;
     }
-    
-    switch (win->type)
-    {
-        case wintype_TextBuffer:
-            win_clear(win->peer);
-            break;
-        case wintype_TextGrid:
-            win_clear(win->peer);
-            break;
-        case wintype_Graphics:
-            win_fillrect(win->peer, win->background,
-                         0, 0,
-                         win->bbox.x1 - win->bbox.x0,
-                         win->bbox.y1 - win->bbox.y0);
-            break;
-    }
+
+    win_clear(win->peer);
 }
 
 void glk_window_move_cursor(window_t *win, glui32 xpos, glui32 ypos)

--- a/resources/PrefsWindow.xib
+++ b/resources/PrefsWindow.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23504" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22690"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23504"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -115,6 +115,7 @@
                 <outlet property="windowTypePopup" destination="Jxm-9E-Ync" id="Hv4-wg-XJ6"/>
                 <outlet property="z6ColorizeCheckBox" destination="8fs-jm-Zp7" id="nYW-Hg-Ew1"/>
                 <outlet property="z6GraphicsPopup" destination="pp3-vl-ffV" id="uNl-l0-0M2"/>
+                <outlet property="zMachineNoErrWinCheckbox" destination="r1L-CL-umy" id="LDu-FV-P8y"/>
                 <outlet property="zVersionTextField" destination="6B5-IO-e9W" id="jwN-QB-cx6"/>
                 <outlet property="zcodeHeader" destination="l66-NN-F50" id="W1I-Sp-q6C"/>
                 <outlet property="zterpMenu" destination="6De-b0-cB0" id="9uo-ZB-Xff"/>
@@ -324,7 +325,7 @@
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="square" bezelStyle="shadowlessSquare" imagePosition="only" alignment="left" lineBreakMode="truncatingTail" imageScaling="proportionallyUpOrDown" inset="2" pullsDown="YES" preferredEdge="maxY" id="KJY-1P-1Ze">
                         <behavior key="behavior" lightByContents="YES"/>
-                        <font key="font" metaFont="menu"/>
+                        <font key="font" metaFont="message"/>
                         <menu key="menu" title="OtherViews" id="Ep7-Pv-hYI">
                             <items>
                                 <menuItem image="NSActionTemplate" hidden="YES" id="OYG-LJ-Hpm"/>
@@ -975,7 +976,7 @@
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" title="Don't show" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="XqL-Ta-baA" id="fN8-qW-e5z">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="menu"/>
+                        <font key="font" metaFont="message"/>
                         <menu key="menu" id="f4f-3N-Tmq">
                             <items>
                                 <menuItem title="Don't show" state="on" id="XqL-Ta-baA"/>
@@ -1054,11 +1055,11 @@
         </customView>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="8bM-HF-6YZ" userLabel="Format Settings">
-            <rect key="frame" x="0.0" y="0.0" width="560" height="528"/>
+            <rect key="frame" x="0.0" y="0.0" width="560" height="543"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CYg-7T-XS8">
-                    <rect key="frame" x="-2" y="503" width="564" height="17"/>
+                    <rect key="frame" x="-2" y="518" width="564" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" lineBreakMode="truncatingMiddle" truncatesLastVisibleLine="YES" sendsActionOnEndEditing="YES" alignment="center" title="Settings for theme Default" usesSingleLineMode="YES" id="l66-NN-F50">
                         <font key="font" metaFont="smallSystem"/>
@@ -1067,7 +1068,7 @@
                     </textFieldCell>
                 </textField>
                 <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rbp-xp-72w">
-                    <rect key="frame" x="88" y="443" width="109" height="16"/>
+                    <rect key="frame" x="88" y="458" width="109" height="16"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" lineBreakMode="truncatingMiddle" truncatesLastVisibleLine="YES" sendsActionOnEndEditing="YES" alignment="right" title="Arrow key usage:" usesSingleLineMode="YES" id="e8w-xX-ZXY">
                         <font key="font" metaFont="system"/>
@@ -1075,22 +1076,13 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pu3-o1-tDI">
-                    <rect key="frame" x="77" y="345" width="120" height="16"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <textFieldCell key="cell" lineBreakMode="truncatingMiddle" truncatesLastVisibleLine="YES" sendsActionOnEndEditing="YES" alignment="right" title="Interpreter version:" usesSingleLineMode="YES" id="h7a-MT-Bfz">
-                        <font key="font" metaFont="system"/>
-                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6De-b0-cB0">
-                    <rect key="frame" x="197" y="339" width="207" height="25"/>
+                    <rect key="frame" x="197" y="354" width="207" height="25"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <string key="toolTip">Sets the Z-code interpreter type reported to the game. Most modern games ignore this setting, but this can change the behaviour of some Infocom games.</string>
                     <popUpButtonCell key="cell" type="push" title="1. DECSystem-20" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="1" imageScaling="proportionallyDown" inset="2" selectedItem="imX-e5-G2g" id="7S7-jE-hTF">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="menu"/>
+                        <font key="font" metaFont="message"/>
                         <menu key="menu" id="wj5-RS-pHn">
                             <items>
                                 <menuItem title="1. DECSystem-20" state="on" tag="1" id="imX-e5-G2g">
@@ -1134,7 +1126,7 @@
                     </connections>
                 </popUpButton>
                 <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cyE-31-4p4">
-                    <rect key="frame" x="80" y="408" width="117" height="16"/>
+                    <rect key="frame" x="80" y="423" width="117" height="16"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" lineBreakMode="truncatingMiddle" truncatesLastVisibleLine="YES" sendsActionOnEndEditing="YES" alignment="right" title="High system beep:" usesSingleLineMode="YES" id="8lk-zD-Gh4">
                         <font key="font" metaFont="system"/>
@@ -1143,11 +1135,11 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton toolTip="This sound is used in some Infocom games when the score goes up." verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZgZ-KI-sE8">
-                    <rect key="frame" x="197" y="401" width="207" height="25"/>
+                    <rect key="frame" x="197" y="416" width="207" height="25"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" title="Basso" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="Y6e-Ph-Nbw" id="8BX-bb-56w">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="menu"/>
+                        <font key="font" metaFont="message"/>
                         <menu key="menu" id="Bwv-ed-dTK">
                             <items>
                                 <menuItem title="Basso" state="on" id="Y6e-Ph-Nbw">
@@ -1205,7 +1197,7 @@
                     </connections>
                 </popUpButton>
                 <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5ZB-Aw-cwI">
-                    <rect key="frame" x="84" y="381" width="113" height="16"/>
+                    <rect key="frame" x="84" y="396" width="113" height="16"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" lineBreakMode="truncatingMiddle" truncatesLastVisibleLine="YES" sendsActionOnEndEditing="YES" alignment="right" title="Low system beep:" usesSingleLineMode="YES" id="cAG-dj-bI0">
                         <font key="font" metaFont="system"/>
@@ -1214,11 +1206,11 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton toolTip="This sound is used in some Infocom games to announce warnings or errors." verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="q2A-r7-Oue">
-                    <rect key="frame" x="197" y="374" width="207" height="25"/>
+                    <rect key="frame" x="197" y="389" width="207" height="25"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" title="Basso" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="fOm-nF-5oT" id="P8D-W7-SWR">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="menu"/>
+                        <font key="font" metaFont="message"/>
                         <menu key="menu" id="JyU-da-2Hb">
                             <items>
                                 <menuItem title="Basso" state="on" id="fOm-nF-5oT">
@@ -1274,8 +1266,17 @@
                         <action selector="changeBeepLowMenu:" target="-2" id="fJi-aG-nKK"/>
                     </connections>
                 </popUpButton>
+                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pu3-o1-tDI">
+                    <rect key="frame" x="77" y="360" width="120" height="16"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" lineBreakMode="truncatingMiddle" truncatesLastVisibleLine="YES" sendsActionOnEndEditing="YES" alignment="right" title="Interpreter version:" usesSingleLineMode="YES" id="h7a-MT-Bfz">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
                 <textField toolTip="Version letter used by Z-code interpreters. Games will sometimes print this, otherwise it has no effect." focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6B5-IO-e9W">
-                    <rect key="frame" x="408" y="342" width="25" height="21"/>
+                    <rect key="frame" x="408" y="357" width="25" height="21"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="center" title="Z" drawsBackground="YES" usesSingleLineMode="YES" id="aA8-0R-Xot">
                         <font key="font" metaFont="smallSystem"/>
@@ -1290,69 +1291,50 @@
                         <outlet property="formatter" destination="B2Q-lK-znP" id="cEf-UX-nHe"/>
                     </connections>
                 </textField>
-                <button toolTip="Show quote boxes as floating, fading windows." verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FC7-pa-Rgw">
-                    <rect key="frame" x="198" y="230" width="140" height="18"/>
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uIw-qh-CCA">
+                    <rect key="frame" x="76" y="334" width="121" height="16"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <buttonCell key="cell" type="check" title="Fancy quote boxes" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="0QR-ab-KZI">
-                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                        <font key="font" metaFont="system"/>
-                    </buttonCell>
-                    <connections>
-                        <action selector="changeQuoteBoxCheckBox:" target="-2" id="0m7-xK-Qcv"/>
-                    </connections>
-                </button>
-                <button toolTip="Some games pause for dramatic effect. Turn it off here." verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0SI-L5-3sn">
-                    <rect key="frame" x="198" y="85" width="67" height="18"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <buttonCell key="cell" type="check" title="Delays" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="4AK-pT-gl4">
-                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                        <font key="font" metaFont="system"/>
-                    </buttonCell>
-                    <connections>
-                        <action selector="changeScottAdamsDelay:" target="-2" id="Mfd-cg-vXv"/>
-                    </connections>
-                </button>
-                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="N2z-zF-leq">
-                    <rect key="frame" x="42" y="118" width="155" height="16"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Upper window inventory:" id="QZE-7T-mZB">
-                        <font key="font" metaFont="system"/>
+                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Preferred graphics:" id="uwM-Lf-NrX">
+                        <font key="font" usesAppearanceFont="YES"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <popUpButton toolTip="Whether to show inventory in the status window. Required for some TI-99/4A games." verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5xf-qh-Vim">
-                    <rect key="frame" x="197" y="111" width="207" height="25"/>
+                <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pp3-vl-ffV">
+                    <rect key="frame" x="197" y="327" width="207" height="25"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <popUpButtonCell key="cell" type="push" title="Automatic" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="wKL-gP-zkE" id="IZu-Eq-dT6">
+                    <popUpButtonCell key="cell" type="push" title="Amiga/Mac Color" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="EOs-e5-4bz" id="w9a-or-aOf">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="menu"/>
-                        <menu key="menu" id="DYI-Er-htq">
+                        <font key="font" metaFont="message"/>
+                        <menu key="menu" id="xq9-4K-GuP">
                             <items>
-                                <menuItem title="Automatic" state="on" id="wKL-gP-zkE"/>
-                                <menuItem title="On" tag="1" id="Jrs-OK-CF6"/>
-                                <menuItem title="Off" tag="2" id="ib2-wg-acs"/>
+                                <menuItem title="Amiga/Mac Color" state="on" id="EOs-e5-4bz" userLabel="Amiga/Mac color"/>
+                                <menuItem title="Mac B/W" tag="1" id="j2r-ik-gqE" userLabel="Mac B/W"/>
+                                <menuItem title="Apple II" tag="2" id="fnL-vj-KNo" userLabel="Apple II"/>
+                                <menuItem title="VGA" tag="3" id="Ed1-sq-zwH" userLabel="VGA"/>
+                                <menuItem title="EGA" tag="4" id="jp0-kw-P7b" userLabel="EGA"/>
+                                <menuItem title="CGA" tag="5" id="CFG-J7-71R" userLabel="CGA"/>
+                                <menuItem title="Blorb" tag="6" id="7gD-4q-P7R" userLabel="Blorb"/>
                             </items>
                         </menu>
                     </popUpButtonCell>
                     <connections>
-                        <action selector="changeScottAdamsInventory:" target="-2" id="Wss-H3-l50"/>
+                        <action selector="changez6GraphicsMenu:" target="-2" id="F49-dT-7eB"/>
                     </connections>
                 </popUpButton>
-                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cFf-OI-7lG">
-                    <rect key="frame" x="198" y="63" width="149" height="18"/>
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8fs-jm-Zp7">
+                    <rect key="frame" x="198" y="267" width="163" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <string key="toolTip">Slow down vector graphics drawing to simulate the look on the original machines. Currently only works in the 11 Mysterious Adventures.</string>
-                    <buttonCell key="cell" type="check" title="Slow vector drawing" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="aUU-IN-zWc">
+                    <buttonCell key="cell" type="check" title="Colorize 1-bit graphics" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="IUV-AF-qjZ">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                     <connections>
-                        <action selector="changeScottAdamsSlowDraw:" target="-2" id="FeH-NG-bF5"/>
+                        <action selector="changez6ColorizeCheckBox:" target="-2" id="xK0-Wa-uNY"/>
                     </connections>
                 </button>
                 <textField toolTip="Adjust the graphic font height to avoid gaps and make diagonal lines smoother. Useful in Beyond Zork." focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9mZ-cN-L2R">
-                    <rect key="frame" x="198" y="284" width="203" height="16"/>
+                    <rect key="frame" x="198" y="299" width="203" height="16"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" lineBreakMode="truncatingMiddle" truncatesLastVisibleLine="YES" sendsActionOnEndEditing="YES" alignment="right" title="Graphic font vertical adjustment:" usesSingleLineMode="YES" id="VrB-gs-vFa">
                         <font key="font" metaFont="system"/>
@@ -1361,7 +1343,7 @@
                     </textFieldCell>
                 </textField>
                 <textField toolTip="Adjust the graphic font height to avoid gaps and make diagonal lines smoother. Useful in Beyond Zork." focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" tag="13" translatesAutoresizingMaskIntoConstraints="NO" id="gPR-Kk-wPd">
-                    <rect key="frame" x="404" y="283" width="27" height="18"/>
+                    <rect key="frame" x="404" y="298" width="27" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" tag="13" title="15" drawsBackground="YES" id="pGd-xy-4dU">
                         <numberFormatter key="formatter" formatterBehavior="10_0" positiveFormat="#,##0" negativeFormat="-#,##0" thousandSeparator=" " id="XIB-uC-kZd">
@@ -1382,15 +1364,65 @@
                     </connections>
                 </textField>
                 <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JdQ-li-puR">
-                    <rect key="frame" x="428" y="279" width="19" height="26"/>
+                    <rect key="frame" x="428" y="294" width="19" height="26"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <stepperCell key="cell" continuous="YES" alignment="left" minValue="-20" maxValue="20" id="RA1-Ez-l5G"/>
+                    <stepperCell key="cell" continuous="YES" alignment="left" minValue="-100" maxValue="100" id="RA1-Ez-l5G"/>
                     <connections>
                         <action selector="changeBZVerticalAdjustment:" target="-2" id="adk-zn-g9M"/>
                     </connections>
                 </stepper>
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="N2z-zF-leq">
+                    <rect key="frame" x="42" y="121" width="155" height="16"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Upper window inventory:" id="QZE-7T-mZB">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <popUpButton toolTip="Whether to show inventory in the status window. Required for some TI-99/4A games." verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5xf-qh-Vim">
+                    <rect key="frame" x="197" y="114" width="207" height="25"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <popUpButtonCell key="cell" type="push" title="Automatic" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="wKL-gP-zkE" id="IZu-Eq-dT6">
+                        <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="message"/>
+                        <menu key="menu" id="DYI-Er-htq">
+                            <items>
+                                <menuItem title="Automatic" state="on" id="wKL-gP-zkE"/>
+                                <menuItem title="On" tag="1" id="Jrs-OK-CF6"/>
+                                <menuItem title="Off" tag="2" id="ib2-wg-acs"/>
+                            </items>
+                        </menu>
+                    </popUpButtonCell>
+                    <connections>
+                        <action selector="changeScottAdamsInventory:" target="-2" id="Wss-H3-l50"/>
+                    </connections>
+                </popUpButton>
+                <button toolTip="Some games pause for dramatic effect. Turn it off here." verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0SI-L5-3sn">
+                    <rect key="frame" x="198" y="88" width="67" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Delays" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="4AK-pT-gl4">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="changeScottAdamsDelay:" target="-2" id="Mfd-cg-vXv"/>
+                    </connections>
+                </button>
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cFf-OI-7lG">
+                    <rect key="frame" x="198" y="66" width="149" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <string key="toolTip">Slow down vector graphics drawing to simulate the look on the original machines. Currently only works in the 11 Mysterious Adventures.</string>
+                    <buttonCell key="cell" type="check" title="Slow vector drawing" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="aUU-IN-zWc">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="changeScottAdamsSlowDraw:" target="-2" id="FeH-NG-bF5"/>
+                    </connections>
+                </button>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="G5L-Nt-fC9">
-                    <rect key="frame" x="-2" y="473" width="564" height="16"/>
+                    <rect key="frame" x="-2" y="488" width="564" height="16"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Specific to Z-machine games" id="TEv-pj-l2l">
                         <font key="font" usesAppearanceFont="YES"/>
@@ -1399,7 +1431,7 @@
                     </textFieldCell>
                 </textField>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OOm-Ik-6b4">
-                    <rect key="frame" x="-2" y="175" width="564" height="16"/>
+                    <rect key="frame" x="-2" y="178" width="564" height="16"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Specific to Scott Adams style games" id="hhd-nX-YS1">
                         <font key="font" usesAppearanceFont="YES"/>
@@ -1408,11 +1440,11 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton toolTip="Try to make the colors look like on one of the original machines." verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GQ0-dI-BSS">
-                    <rect key="frame" x="197" y="138" width="207" height="25"/>
+                    <rect key="frame" x="197" y="141" width="207" height="25"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" title="Automatic" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="AdZ-1F-ake" id="zTl-zA-T3p">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="menu"/>
+                        <font key="font" metaFont="message"/>
                         <menu key="menu" id="Ll4-i4-LmR">
                             <items>
                                 <menuItem title="Automatic" state="on" id="AdZ-1F-ake"/>
@@ -1428,7 +1460,7 @@
                     </connections>
                 </popUpButton>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="k2o-if-GSb">
-                    <rect key="frame" x="106" y="145" width="91" height="16"/>
+                    <rect key="frame" x="106" y="148" width="91" height="16"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Image palette:" id="4uq-cs-Wof">
                         <font key="font" metaFont="system"/>
@@ -1437,12 +1469,12 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fOb-mm-Uja">
-                    <rect key="frame" x="197" y="436" width="207" height="25"/>
+                    <rect key="frame" x="197" y="451" width="207" height="25"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <string key="toolTip">Resolve the conflict between later Infocom games' usage of the arrow keys and the standard behavior to step through command history and edit with them.</string>
                     <popUpButtonCell key="cell" type="push" title="↑ and ↓ work as in original" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="oIP-mr-bpC" id="COo-em-V8P">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="menu"/>
+                        <font key="font" metaFont="message"/>
                         <menu key="menu" id="fau-OE-Vj6">
                             <items>
                                 <menuItem title="↑ and ↓ work as in original" state="on" toolTip="↑ and ↓ navigate menus and status windows.  ⌘↑ and ⌘↓ step through command history." id="oIP-mr-bpC" userLabel="Standard">
@@ -1462,7 +1494,7 @@
                     </connections>
                 </popUpButton>
                 <button toolTip="The room description will flicker at certain places like some original interpreters." verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kFW-u2-bVp">
-                    <rect key="frame" x="198" y="41" width="66" height="18"/>
+                    <rect key="frame" x="198" y="44" width="66" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Flicker" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="IAz-Z3-Tr3">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1472,50 +1504,30 @@
                         <action selector="changeScottAdamsFlicker:" target="-2" id="6XG-67-FQa"/>
                     </connections>
                 </button>
-                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uIw-qh-CCA">
-                    <rect key="frame" x="76" y="319" width="121" height="16"/>
+                <button toolTip="Show quote boxes as floating, fading windows." verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="r1L-CL-umy">
+                    <rect key="frame" x="197" y="245" width="202" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Preferred graphics:" id="uwM-Lf-NrX">
-                        <font key="font" usesAppearanceFont="YES"/>
-                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
-                <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pp3-vl-ffV">
-                    <rect key="frame" x="197" y="312" width="207" height="25"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <popUpButtonCell key="cell" type="push" title="Amiga/Mac Color" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="EOs-e5-4bz" id="w9a-or-aOf">
-                        <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="menu"/>
-                        <menu key="menu" id="xq9-4K-GuP">
-                            <items>
-                                <menuItem title="Amiga/Mac Color" state="on" id="EOs-e5-4bz" userLabel="Amiga/Mac color"/>
-                                <menuItem title="Mac B/W" tag="1" id="j2r-ik-gqE" userLabel="Mac B/W"/>
-                                <menuItem title="Apple II" tag="2" id="fnL-vj-KNo" userLabel="Apple II"/>
-                                <menuItem title="VGA" tag="3" id="Ed1-sq-zwH" userLabel="VGA"/>
-                                <menuItem title="EGA" tag="4" id="jp0-kw-P7b" userLabel="EGA"/>
-                                <menuItem title="CGA" tag="5" id="CFG-J7-71R" userLabel="CGA"/>
-                                <menuItem title="Blorb" tag="6" id="7gD-4q-P7R" userLabel="Blorb"/>
-                            </items>
-                        </menu>
-                    </popUpButtonCell>
-                    <connections>
-                        <action selector="changez6GraphicsMenu:" target="-2" id="F49-dT-7eB"/>
-                    </connections>
-                </popUpButton>
-                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8fs-jm-Zp7">
-                    <rect key="frame" x="198" y="252" width="163" height="18"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <buttonCell key="cell" type="check" title="Colorize 1-bit graphics" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="IUV-AF-qjZ">
+                    <buttonCell key="cell" type="check" title="Redirect text to main window" bezelStyle="regularSquare" imagePosition="left" inset="2" id="N52-GG-l7u">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                     <connections>
-                        <action selector="changez6ColorizeCheckBox:" target="-2" id="xK0-Wa-uNY"/>
+                        <action selector="changeNoErrWinCheckBox:" target="-2" id="OKp-Bq-ogn"/>
+                    </connections>
+                </button>
+                <button toolTip="Show quote boxes as floating, fading windows." verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FC7-pa-Rgw">
+                    <rect key="frame" x="198" y="223" width="140" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Fancy quote boxes" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="0QR-ab-KZI">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="changeQuoteBoxCheckBox:" target="-2" id="0m7-xK-Qcv"/>
                     </connections>
                 </button>
             </subviews>
-            <point key="canvasLocation" x="493" y="949"/>
+            <point key="canvasLocation" x="493" y="956.5"/>
         </customView>
         <customView id="U1d-3r-zfM" userLabel="VoiceOver Settings">
             <rect key="frame" x="0.0" y="0.0" width="560" height="267"/>
@@ -1557,7 +1569,7 @@
                     <string key="toolTip">When VoiceOver is active, Spatterlight tries to detect some types of menus, unless disabled here. This setting also determines how detected menu lines are spoken.</string>
                     <popUpButtonCell key="cell" type="push" title="Text only" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="1" imageScaling="proportionallyDown" inset="2" selectedItem="EvJ-bs-zkC" id="clM-44-Y5N">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="menu"/>
+                        <font key="font" metaFont="message"/>
                         <menu key="menu" id="lDm-UQ-w9u">
                             <items>
                                 <menuItem title="Don't detect menus" toolTip="Don't try to detect menus at all." id="b2m-qv-1JV" userLabel="Don't detect menus"/>
@@ -1585,7 +1597,7 @@
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" title="With descriptions" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="fw9-TN-HtJ" id="blv-x1-phF" userLabel="Images pop-up">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="menu"/>
+                        <font key="font" metaFont="message"/>
                         <menu key="menu" id="2Ah-Ub-MSW">
                             <items>
                                 <menuItem title="With descriptions" state="on" toolTip="Only speak custom descriptions of images that have them." id="fw9-TN-HtJ" userLabel="With descriptions"/>
@@ -1721,7 +1733,7 @@
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" title="Ignore errors" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="mig-vD-S0l" id="ve4-Rh-7ci">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="menu"/>
+                        <font key="font" metaFont="message"/>
                         <menu key="menu" id="YHK-EX-ocW">
                             <items>
                                 <menuItem title="Ignore errors" state="on" id="mig-vD-S0l" userLabel="Ignore errors"/>
@@ -1896,7 +1908,7 @@
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" title="Don't replace images" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="1" imageScaling="proportionallyDown" inset="2" selectedItem="uLU-6T-Z1Y" id="i5C-G1-dec">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="menu"/>
+                        <font key="font" metaFont="message"/>
                         <menu key="menu" id="jjQ-eB-0m3">
                             <items>
                                 <menuItem title="Don't replace images" state="on" tag="1" id="uLU-6T-Z1Y" userLabel="Don't replace"/>

--- a/resources/Spatterlight.xcdatamodeld/Spatterlight 14.xcdatamodel/contents
+++ b/resources/Spatterlight.xcdatamodeld/Spatterlight 14.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22758" systemVersion="23F79" minimumToolsVersion="Automatic" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="14">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24B91" minimumToolsVersion="Automatic" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="14">
     <entity name="Game" representedClassName="Game" syncable="YES">
         <attribute name="added" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData"/>
         <attribute name="autosaved" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
@@ -164,8 +164,8 @@
         <attribute name="winSpacingY" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="z6Colorize1Bit" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="z6GraphicsType" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="z6Simulate16Color" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="zMachineLetter" optional="YES" attributeType="String" defaultValueString="S"/>
+        <attribute name="zMachineNoErrWin" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="zMachineTerp" optional="YES" attributeType="Integer 32" minValueString="1" maxValueString="11" defaultValueString="4" usesScalarValueType="YES"/>
         <relationship name="bufAlert" optional="YES" minCount="1" maxCount="1" deletionRule="Cascade" destinationEntity="GlkStyle" inverseName="bufAlert" inverseEntity="GlkStyle"/>
         <relationship name="bufBlock" optional="YES" minCount="1" maxCount="1" deletionRule="Cascade" destinationEntity="GlkStyle" inverseName="bufBlock" inverseEntity="GlkStyle"/>

--- a/terps/bocfel/LICENSE
+++ b/terps/bocfel/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright 2009-2025 Chris Spiegel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/terps/bocfel/blorb.cpp
+++ b/terps/bocfel/blorb.cpp
@@ -1,18 +1,6 @@
 // Copyright 2010-2021 Chris Spiegel.
 //
-// This file is part of Bocfel.
-//
-// Bocfel is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License, version
-// 2 or 3, as published by the Free Software Foundation.
-//
-// Bocfel is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with Bocfel. If not, see <http://www.gnu.org/licenses/>.
+// SPDX-License-Identifier: MIT
 
 #include <memory>
 #include <stdexcept>

--- a/terps/bocfel/bocfel-spatterlight/spatterlight-autosave.h
+++ b/terps/bocfel/bocfel-spatterlight/spatterlight-autosave.h
@@ -87,6 +87,14 @@ typedef struct library_state_data_struct {
     int current_input_length;
     int number_of_journey_words;
     struct JourneyWords journey_words[4];
+
+    int current_graphics_win_tag;
+    int graphics_fg_tag;
+
+    int stored_lower_tag;
+
+    int hints_depth;
+    int slideshow_pic;
 } library_state_data;
 
 void recover_library_state(library_state_data *dat);

--- a/terps/bocfel/bocfel-spatterlight/spatterlight-autosave.mm
+++ b/terps/bocfel/bocfel-spatterlight/spatterlight-autosave.mm
@@ -145,7 +145,8 @@ void spatterlight_do_autosave(enum SaveOpcode saveopcode) {
     return;
 }
 
-extern bool just_autorestored;
+extern bool v6_autorestore_hacks_needed;
+extern bool v6_read_hacks_needed;
 
 // Restore an autosaved game, if one exists.
 // Returns true if the game was restored successfully, false if not.
@@ -251,7 +252,8 @@ bool spatterlight_restore_autosave(enum SaveOpcode *saveopcode)
         
     }
     
-    just_autorestored = true;
+    v6_autorestore_hacks_needed = true;
+    v6_read_hacks_needed = true;
 
     return true;
 }
@@ -284,6 +286,12 @@ static void spatterlight_library_archive(TempLibrary *library, NSCoder *encoder)
     [encoder encodeInt32:(int32_t)library_state.selected_journey_column forKey:@"bocfel_selected_journey_column"];
     [encoder encodeInt32:(int32_t)library_state.current_input_mode forKey:@"bocfel_current_input_mode"];
     [encoder encodeInt32:(int32_t)library_state.current_input_length forKey:@"bocfel_current_input_length"];
+
+    [encoder encodeInt32:(int32_t)library_state.current_graphics_win_tag forKey:@"bocfel_current_graphics_win_tag"];
+    [encoder encodeInt32:(int32_t)library_state.graphics_fg_tag forKey:@"bocfel_graphics_fg_tag"];
+    [encoder encodeInt32:(int32_t)library_state.stored_lower_tag forKey:@"bocfel_stored_lower_tag"];
+    [encoder encodeInt32:(int32_t)library_state.hints_depth forKey:@"bocfel_hints_depth"];
+    [encoder encodeInt32:(int32_t)library_state.slideshow_pic forKey:@"bocfel_slideshow_pic"];
 
     if (library_state.number_of_journey_words > 0) {
         NSMutableArray<NSArray *> *tempMutArray = [[NSMutableArray alloc] initWithCapacity:library_state.number_of_journey_words];
@@ -326,6 +334,12 @@ static void spatterlight_library_unarchive(TempLibrary *library, NSCoder *decode
     library_state.selected_journey_column = [decoder decodeInt32ForKey:@"bocfel_selected_journey_column"];
     library_state.current_input_mode = (inputMode)[decoder decodeInt32ForKey:@"bocfel_current_input_mode"];
     library_state.current_input_length = [decoder decodeInt32ForKey:@"bocfel_current_input_length"];
+
+    library_state.current_graphics_win_tag = [decoder decodeInt32ForKey:@"bocfel_current_graphics_win_tag"];;
+    library_state.graphics_fg_tag = [decoder decodeInt32ForKey:@"bocfel_graphics_fg_tag"];
+    library_state.stored_lower_tag = [decoder decodeInt32ForKey:@"bocfel_stored_lower_tag"];
+    library_state.hints_depth = [decoder decodeInt32ForKey:@"bocfel_hints_depth"];
+    library_state.slideshow_pic = [decoder decodeInt32ForKey:@"bocfel_slideshow_pic"];
 
     NSArray<NSArray *> *tempArray = [decoder decodeObjectOfClass:[NSArray class] forKey:@"bocfel_printed_journey_words"];
     library_state.number_of_journey_words = tempArray.count;

--- a/terps/bocfel/branch.cpp
+++ b/terps/bocfel/branch.cpp
@@ -1,18 +1,6 @@
 // Copyright 2010-2021 Chris Spiegel.
 //
-// This file is part of Bocfel.
-//
-// Bocfel is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License, version
-// 2 or 3, as published by the Free Software Foundation.
-//
-// Bocfel is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with Bocfel. If not, see <http://www.gnu.org/licenses/>.
+// SPDX-License-Identifier: MIT
 
 #include "branch.h"
 #include "memory.h"

--- a/terps/bocfel/dict.cpp
+++ b/terps/bocfel/dict.cpp
@@ -1,18 +1,6 @@
 // Copyright 2009-2021 Chris Spiegel.
 //
-// This file is part of Bocfel.
-//
-// Bocfel is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License, version
-// 2 or 3, as published by the Free Software Foundation.
-//
-// Bocfel is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with Bocfel. If not, see <http://www.gnu.org/licenses/>.
+// SPDX-License-Identifier: MIT
 
 #include <array>
 #include <cstdlib>

--- a/terps/bocfel/glkstart.cpp
+++ b/terps/bocfel/glkstart.cpp
@@ -1,18 +1,6 @@
 // Copyright 2010-2021 Chris Spiegel.
 //
-// This file is part of Bocfel.
-//
-// Bocfel is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License, version
-// 2 or 3, as published by the Free Software Foundation.
-//
-// Bocfel is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with Bocfel. If not, see <http://www.gnu.org/licenses/>.
+// SPDX-License-Identifier: MIT
 
 #include <initializer_list>
 #include <string>

--- a/terps/bocfel/iff.cpp
+++ b/terps/bocfel/iff.cpp
@@ -1,18 +1,6 @@
 // Copyright 2010-2021 Chris Spiegel.
 //
-// This file is part of Bocfel.
-//
-// Bocfel is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License, version
-// 2 or 3, as published by the Free Software Foundation.
-//
-// Bocfel is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with Bocfel. If not, see <http://www.gnu.org/licenses/>.
+// SPDX-License-Identifier: MIT
 
 #include <algorithm>
 #include <utility>

--- a/terps/bocfel/io.cpp
+++ b/terps/bocfel/io.cpp
@@ -1,18 +1,6 @@
 // Copyright 2010-2021 Chris Spiegel.
 //
-// This file is part of Bocfel.
-//
-// Bocfel is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License, version
-// 2 or 3, as published by the Free Software Foundation.
-//
-// Bocfel is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with Bocfel. If not, see <http://www.gnu.org/licenses/>.
+// SPDX-License-Identifier: MIT
 
 #include <climits>
 #include <cstdio>

--- a/terps/bocfel/mathop.cpp
+++ b/terps/bocfel/mathop.cpp
@@ -1,18 +1,6 @@
 // Copyright 2010-2021 Chris Spiegel.
 //
-// This file is part of Bocfel.
-//
-// Bocfel is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License, version
-// 2 or 3, as published by the Free Software Foundation.
-//
-// Bocfel is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with Bocfel. If not, see <http://www.gnu.org/licenses/>.
+// SPDX-License-Identifier: MIT
 
 #include "mathop.h"
 #include "branch.h"

--- a/terps/bocfel/memory.cpp
+++ b/terps/bocfel/memory.cpp
@@ -1,18 +1,6 @@
 // Copyright 2010-2021 Chris Spiegel.
 //
-// This file is part of Bocfel.
-//
-// Bocfel is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License, version
-// 2 or 3, as published by the Free Software Foundation.
-//
-// Bocfel is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with Bocfel. If not, see <http://www.gnu.org/licenses/>.
+// SPDX-License-Identifier: MIT
 
 #include <cstdlib>
 #include <iomanip>

--- a/terps/bocfel/meta.cpp
+++ b/terps/bocfel/meta.cpp
@@ -1,18 +1,6 @@
 // Copyright 2013-2021 Chris Spiegel.
 //
-// This file is part of Bocfel.
-//
-// Bocfel is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License, version
-// 2 or 3, as published by the Free Software Foundation.
-//
-// Bocfel is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with Bocfel. If not, see <http://www.gnu.org/licenses/>.
+// SPDX-License-Identifier: MIT
 
 #include <array>
 #include <cstring>

--- a/terps/bocfel/objects.cpp
+++ b/terps/bocfel/objects.cpp
@@ -1,18 +1,6 @@
 // Copyright 2009-2021 Chris Spiegel.
 //
-// This file is part of Bocfel.
-//
-// Bocfel is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License, version
-// 2 or 3, as published by the Free Software Foundation.
-//
-// Bocfel is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with Bocfel. If not, see <http://www.gnu.org/licenses/>.
+// SPDX-License-Identifier: MIT
 
 #include "objects.h"
 #include "branch.h"
@@ -333,6 +321,10 @@ void internal_put_prop(uint16_t object, uint16_t property, uint16_t value)
     } else {
         user_store_word(propaddr, zargs[2]);
     }
+}
+
+int16_t internal_get_parent(int16_t obj) {
+    return (parent_of(obj));
 }
 
 #endif

--- a/terps/bocfel/options.cpp
+++ b/terps/bocfel/options.cpp
@@ -1,18 +1,6 @@
 // Copyright 2009-2023 Chris Spiegel.
 //
-// This file is part of Bocfel.
-//
-// Bocfel is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License, version
-// 2 or 3, as published by the Free Software Foundation.
-//
-// Bocfel is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with Bocfel. If not, see <http://www.gnu.org/licenses/>.
+// SPDX-License-Identifier: MIT
 
 #include <algorithm>
 #include <bitset>

--- a/terps/bocfel/osdep.cpp
+++ b/terps/bocfel/osdep.cpp
@@ -1,18 +1,6 @@
 // Copyright 2010-2021 Chris Spiegel.
 //
-// This file is part of Bocfel.
-//
-// Bocfel is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License, version
-// 2 or 3, as published by the Free Software Foundation.
-//
-// Bocfel is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with Bocfel. If not, see <http://www.gnu.org/licenses/>.
+// SPDX-License-Identifier: MIT
 
 #include <climits>
 #include <cstdio>

--- a/terps/bocfel/patches.cpp
+++ b/terps/bocfel/patches.cpp
@@ -1,18 +1,6 @@
 // Copyright 2017-2021 Chris Spiegel.
 //
-// This file is part of Bocfel.
-//
-// Bocfel is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License, version
-// 2 or 3, as published by the Free Software Foundation.
-//
-// Bocfel is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with Bocfel. If not, see <http://www.gnu.org/licenses/>.
+// SPDX-License-Identifier: MIT
 
 #include <algorithm>
 #include <cstring>
@@ -406,6 +394,36 @@ static std::vector<Patch> base_patches = {
         }
     },
 
+    // Journey doubles up the word “essence” when examining Praxix’s
+    // pouch: originally the game printed short descriptions when the
+    // screen was narrow enough, which didn't include the word
+    // “essence”, so it always just printed out an extra “essence”,
+    // knowing that it wasn't shown. However, release 51 changed this so
+    // that the long descriptions, which included “essence”, were
+    // unconditionally printed in this circumstance; but the extra
+    // “essence” remained. This patches out the printing of that extra
+    // word by replacing it with @nop.
+    {
+        "Journey", "890522", 51, 0x4f59,
+        {{ 0x9d9f, 3, {0xb2, 0x80, 0x3e}, {0xb4, 0xb4, 0xb4} }},
+    },
+    {
+        "Journey", "890526", 54, 0x5707,
+        {{ 0x9e2f, 3, {0xb2, 0x80, 0x3e}, {0xb4, 0xb4, 0xb4} }},
+    },
+    {
+        "Journey", "890616", 77, 0xb136,
+        {{ 0xa09f, 3, {0xb2, 0x80, 0x3e}, {0xb4, 0xb4, 0xb4} }},
+    },
+    {
+        "Journey", "890627", 79, 0xff04,
+        {{ 0xa10b, 3, {0xb2, 0x80, 0x3e}, {0xb4, 0xb4, 0xb4} }},
+    },
+    {
+        "Journey", "890706", 83, 0xd2b8,
+        {{ 0xa0ef, 3, {0xb2, 0x80, 0x3e}, {0xb4, 0xb4, 0xb4} }},
+    },
+
     // This is in a routine which iterates over all attributes of an
     // object, but due to an off-by-one error, attribute 48 (0x30) is
     // included, which is not valid, as the last attribute is 47 (0x2f);
@@ -616,9 +634,69 @@ static std::vector<Patch> v6_patches = {
             {
                 0x10e76, 20,
                 {0xda, 0x1f, 0x3d, 0xb1, 0x03, 0xef, 0x3f, 0xff, 0xff, 0xf6, 0x53, 0x01, 0x96, 0x20, 0x7d, 0x00, 0xef, 0x3f, 0xff, 0xfe},
+#ifdef SPATTERLIGHT
+                {0xf6, 0x53, 0x01, 0x03, 0x20, 0x7d, 0x00, 0xda, 0x1f, 0x3d, 0xb1, 0x03, 0xf6, 0x53, 0x01, 0x96, 0x20, 0x7d, 0x00, 0xb4}
+#else
                 {0xf6, 0x53, 0x01, 0x0a, 0x20, 0x7d, 0x00, 0xda, 0x1f, 0x3d, 0xb1, 0x03, 0xf6, 0x53, 0x01, 0x96, 0x20, 0x7d, 0x00, 0xb4}
+#endif
             },
 
+#ifdef SPATTERLIGHT
+        }
+    },
+    {
+        "Arthur", "890502", 40, 0x2f5d,
+        {
+            // <RT-CENTER-PIC ,K-PIC-SWORD-MERLIN>     |   call_2n         #1a824 #03
+            // <CURSET -1> ;"Make cursor go away."     |   set_cursor      #ffff
+            // <INPUT 1 150 ,RT-STOP-READ>             |   read_char       #01 #96 #118e8 -> -(SP)
+            // <CURSET -2> ;"Make cursor come back."   |   set_cursor      #fffe
+            //
+            // is replaced with:
+            //
+            // <INPUT 1 10 ,RT-STOP-READ>              |   read_char        #01 #0a #118e8 -> -(SP)
+            // <RT-CENTER-PIC ,K-PIC-SWORD-MERLIN>     |   call_2n          #1a824 #03
+            // <INPUT 1 150 ,RT-STOP-READ>             |   read_char        #01 #96 #118e8 -> -(SP)
+            // <NOOP>                                  |   nop
+            {
+                0x10cc4, 20,
+                {0xda, 0x1f, 0x44, 0xcf, 0x03, 0xef, 0x3f, 0xff, 0xff, 0xf6, 0x53, 0x01, 0x96, 0x21, 0x00, 0x00, 0xef, 0x3f, 0xff, 0xfe},
+                {0xf6, 0x53, 0x01, 0x03, 0x21, 0x00, 0x00, 0xda, 0x1f, 0x44, 0xcf, 0x03, 0xf6, 0x53, 0x01, 0x96, 0x21, 0x00, 0x00, 0xb4}
+            }
+        },
+    },
+    {
+        "Arthur", "890504", 41, 0xa406,
+        {
+            {
+                0x10cc8, 20,
+                {0xda, 0x1f, 0x44, 0xd2, 0x03, 0xef, 0x3f, 0xff, 0xff, 0xf6, 0x53, 0x01, 0x96, 0x21, 0x01, 0x00, 0xef, 0x3f, 0xff, 0xfe},
+                {0xf6, 0x53, 0x01, 0x03, 0x21, 0x01, 0x00, 0xda, 0x1f, 0x44, 0xd2, 0x03, 0xf6, 0x53, 0x01, 0x96, 0x21, 0x01, 0x00, 0xb4}
+            }
+        },
+    },
+    {
+        "Arthur", "890606", 54, 0x8e4a,
+        {
+            {
+                0x11418, 20,
+                {0xda, 0x1f, 0x49, 0xae, 0x03, 0xef, 0x3f, 0xff, 0xff, 0xf6, 0x53, 0x01, 0x96, 0x21, 0xd4, 0x00, 0xef, 0x3f, 0xff, 0xfe},
+                {0xf6, 0x53, 0x01, 0x03, 0x21, 0xd4, 0x00, 0xda, 0x1f, 0x49, 0xae, 0x03, 0xf6, 0x53, 0x01, 0x96, 0x21, 0xd4, 0x00, 0xb4}
+            }
+        },
+    },
+    {
+        "Arthur", "890622", 63, 0x45eb,
+        {
+            {
+                0x1147e, 20,
+                {0xda, 0x1f, 0x3f, 0x2e, 0x03, 0xef, 0x3f, 0xff, 0xff, 0xf6, 0x53, 0x01, 0x96, 0x22, 0x04, 0x00, 0xef, 0x3f, 0xff, 0xfe},
+                {0xf6, 0x53, 0x01, 0x03, 0x22, 0x04, 0x00, 0xda, 0x1f, 0x3f, 0x2e, 0x03, 0xf6, 0x53, 0x01, 0x96, 0x22, 0x04, 0x00, 0xb4}
+            }
+        },
+    },
+
+#else
             // Parser messages are meant to be displayed on the bottom
             // of the screen, but since Bocfel doesn’t have real V6
             // window support, the messages are displayed inline as with
@@ -633,7 +711,9 @@ static std::vector<Patch> v6_patches = {
             { 0x1124b, 3, {0x7b, 0x0d, 0x0c}, {0xb4, 0xb4, 0xb4} },
             { 0x11257, 3, {0x7b, 0x0c, 0x0d}, {0xb4, 0xb4, 0xb4} },
         },
+
     },
+#endif
 
     {
         "Shogun", "890706", 322, 0x5c88,

--- a/terps/bocfel/process.cpp
+++ b/terps/bocfel/process.cpp
@@ -1,18 +1,6 @@
 // Copyright 2010-2021 Chris Spiegel.
 //
-// This file is part of Bocfel.
-//
-// Bocfel is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License, version
-// 2 or 3, as published by the Free Software Foundation.
-//
-// Bocfel is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with Bocfel. If not, see <http://www.gnu.org/licenses/>.
+// SPDX-License-Identifier: MIT
 
 #include <array>
 #include <functional>
@@ -331,7 +319,7 @@ void process_instructions()
 
         current_instruction = pc;
 #ifdef SPATTERLIGHT
-        if (is_spatterlight_journey) {
+        if (is_spatterlight_arthur || is_spatterlight_journey) {
             check_entrypoints(pc);
         }
 #endif

--- a/terps/bocfel/random.cpp
+++ b/terps/bocfel/random.cpp
@@ -1,18 +1,6 @@
 // Copyright 2010-2021 Chris Spiegel.
 //
-// This file is part of Bocfel.
-//
-// Bocfel is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License, version
-// 2 or 3, as published by the Free Software Foundation.
-//
-// Bocfel is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with Bocfel. If not, see <http://www.gnu.org/licenses/>.
+// SPDX-License-Identifier: MIT
 
 #include <cerrno>
 #include <chrono>

--- a/terps/bocfel/screen.h
+++ b/terps/bocfel/screen.h
@@ -162,10 +162,13 @@ void zbuffer_screen();
 extern GraphicsType graphics_type;
 extern bool centeredText;
 
+extern winid_t current_graphics_buf_win;
+extern winid_t graphics_bg_glk;
+extern winid_t graphics_fg_glk;
+
 struct Window {
     Style style;
-    //    Color fg_color = Color(), bg_color = Color();
-    Color fg_color = Color(Color::Mode::ANSI, 13), bg_color = Color(Color::Mode::ANSI, 14);
+    Color fg_color = Color(), bg_color = Color();
     enum class Font { Query, Normal, Picture, Character, Fixed } font = Font::Normal;
 
     winid_t id = nullptr;
@@ -183,6 +186,7 @@ struct Window {
 
 extern glui32 user_selected_foreground, user_selected_background;
 extern bool is_spatterlight_journey;
+extern bool is_spatterlight_arthur;
 extern std::array<Window, 8> windows;
 
 uint8_t internal_read_char(void);
@@ -191,8 +195,21 @@ void v6_sizewin(Window *win);
 void v6_define_window(Window *win, uint16_t x, uint16_t y, uint16_t width, uint16_t height);
 void v6_restore_hacks(void);
 bool v6_switch_to_allowed_interpreter_number(void);
-void journey_sync_upperwin_size(glui32 width, glui32 height);
+void v6_delete_win(Window *win);
+void v6_delete_glk_win(winid_t win);
+void v6_remap_win(Window *win, int type, winid_t *stored_win);
+void v6_remap_win_to_grid(Window *win);
+void v6_remap_win_to_buffer(Window *win);
+void update_user_defined_colours(void);
+void flush_image_buffer(void);
 
+void v6_sync_upperwin_size(glui32 width, glui32 height);
+void v6_get_and_sync_upperwin_size(void);
+
+void update_arthur_colours(void);
+
+
+void window_change(void);
 void set_current_window(Window *window);
 void transcribe(uint32_t c);
 

--- a/terps/bocfel/sound.cpp
+++ b/terps/bocfel/sound.cpp
@@ -1,18 +1,6 @@
 // Copyright 2011-2021 Chris Spiegel.
 //
-// This file is part of Bocfel.
-//
-// Bocfel is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License, version
-// 2 or 3, as published by the Free Software Foundation.
-//
-// Bocfel is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with Bocfel. If not, see <http://www.gnu.org/licenses/>.
+// SPDX-License-Identifier: MIT
 
 #include <array>
 #include <exception>

--- a/terps/bocfel/stack.cpp
+++ b/terps/bocfel/stack.cpp
@@ -1,18 +1,6 @@
 // Copyright 2010-2021 Chris Spiegel.
 //
-// This file is part of Bocfel.
-//
-// Bocfel is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License, version
-// 2 or 3, as published by the Free Software Foundation.
-//
-// Bocfel is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with Bocfel. If not, see <http://www.gnu.org/licenses/>.
+// SPDX-License-Identifier: MIT
 
 #include <algorithm>
 #include <array>
@@ -122,6 +110,7 @@ private:
             } catch (...) {
                 // If the locale is invalid, don’t worry about it.
             }
+
             formatted_time << std::put_time(lt, "%c");
 
             return formatted_time.str();

--- a/terps/bocfel/stash.cpp
+++ b/terps/bocfel/stash.cpp
@@ -1,18 +1,6 @@
 // Copyright 2021 Chris Spiegel.
 //
-// This file is part of Bocfel.
-//
-// Bocfel is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License, version
-// 2 or 3, as published by the Free Software Foundation.
-//
-// Bocfel is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with Bocfel. If not, see <http://www.gnu.org/licenses/>.
+// SPDX-License-Identifier: MIT
 
 #include <algorithm>
 #include <memory>

--- a/terps/bocfel/unicode.cpp
+++ b/terps/bocfel/unicode.cpp
@@ -1,18 +1,6 @@
 // Copyright 2010-2021 Chris Spiegel.
 //
-// This file is part of Bocfel.
-//
-// Bocfel is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License, version
-// 2 or 3, as published by the Free Software Foundation.
-//
-// Bocfel is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with Bocfel. If not, see <http://www.gnu.org/licenses/>.
+// SPDX-License-Identifier: MIT
 
 #include <array>
 

--- a/terps/bocfel/util.cpp
+++ b/terps/bocfel/util.cpp
@@ -1,18 +1,6 @@
 // Copyright 2010-2021 Chris Spiegel.
 //
-// This file is part of Bocfel.
-//
-// Bocfel is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License, version
-// 2 or 3, as published by the Free Software Foundation.
-//
-// Bocfel is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with Bocfel. If not, see <http://www.gnu.org/licenses/>.
+// SPDX-License-Identifier: MIT
 
 #include <cstdarg>
 #include <cstdio>
@@ -30,6 +18,7 @@
 
 #ifdef ZTERP_GLK
 #include <glk.h>
+
 #ifdef SPATTERLIGHT
 extern glui32 gli_error_handling;
 
@@ -40,6 +29,7 @@ enum
     ERRORS_ARE_FATAL
 };
 #endif // SPATTERLIGHT
+
 #endif
 
 // Values are usually stored in a uint16_t because most parts of the

--- a/terps/bocfel/z6/arthur.cpp
+++ b/terps/bocfel/z6/arthur.cpp
@@ -1,0 +1,823 @@
+//
+//  arthur.cpp
+//  bocfel6
+//
+//  Created by Administrator on 2023-07-18.
+//
+
+extern "C" {
+#include "glk.h"
+#include "glkimp.h"
+}
+
+#include "draw_image.hpp"
+#include "entrypoints.hpp"
+#include "memory.h"
+#include "objects.h"
+#include "options.h"
+#include "screen.h"
+#include "zterp.h"
+#include "unicode.h"
+#include "v6_specific.h"
+#include "v6_shared.hpp"
+
+#include "arthur.hpp"
+
+extern float imagescalex, imagescaley;
+
+ArthurGlobals ag;
+ArthurRoutines ar;
+ArthurTables at;
+
+#define K_PIC_TITLE 1
+
+#define K_PIC_SWORD 2
+#define K_PIC_SWORD_MERLIN 3
+
+#define K_PIC_ENDGAME 84
+#define K_PIC_ANGRY_DEMON 85
+
+#define K_PIC_BANNER 54
+#define K_PIC_BANNER_MARGIN 100
+#define K_MAP_SCROLL 137
+
+#define K_PIC_CHURCHYARD 4
+#define K_PIC_PARADE_AREA 17
+#define K_PIC_AIR_SCENE 163
+
+#define K_PIC_ISLAND_DOOR 158
+#define K_PIC_ISLAND_DOOR_OFF 159
+
+#define K_PIC_STONE_2 9
+
+
+extern Window *mainwin, *curwin;
+
+#define ARTHUR_GRAPHICS_BG windows[7]
+#define ARTHUR_ROOM_GRAPHIC_WIN windows[2]
+#define ARTHUR_ERROR_WINDOW windows[3]
+
+extern int current_picture;
+
+bool showing_wide_arthur_room_image = false;
+
+static int arthur_text_top_margin = -1;
+static int arthur_x_margin = 0;
+
+int arthur_pic_top_margin = 0;
+
+static bool is_arthur_stamp_image(int picnum) {
+    switch (picnum) {
+        case 6:
+        case 9:
+        case 80:
+        case 83:
+        case 88:
+        case 91:
+        case 93:
+        case 95:
+        case 97:
+        case 99:
+        case 104:
+        case 156:
+        case 158:
+        case 161:
+        case 169:
+            return true;
+        default:
+            break;
+    }
+    return false;
+}
+
+static bool is_arthur_room_image(int picnum) {
+    switch (picnum) {
+        case 101:
+        case 102:
+        case 154:
+        case 157:
+        case 162:
+        case 163: // K-PIC-AIR-SCENE
+        case 165:
+        case 166:
+        case 167:
+            return true;
+        case 6:
+        case 9:
+        case 54:
+        case 80:
+        case 83:
+        case 88:
+            return false;
+        default:
+            if (picnum >= 4 && picnum <= 89)
+                return true;
+    }
+    return false;
+}
+
+bool is_arthur_map_image(int picnum) {
+    return (picnum >= 105 && picnum <= 153);
+}
+
+void adjust_arthur_top_margin(void) {
+    int mapheight, borderheight, margin;
+    get_image_size(K_MAP_SCROLL, &margin, &mapheight); // Get height of map background image
+    get_image_size(K_PIC_BANNER_MARGIN, nullptr, &borderheight); // Get height of border measuring dummy image
+    float y_margin = mapheight * imagescaley;
+    arthur_text_top_margin = ceil(y_margin / gcellh) * gcellh;
+    arthur_pic_top_margin = arthur_text_top_margin / imagescaley - borderheight - 4;
+    if (arthur_pic_top_margin < 0)
+        arthur_pic_top_margin = 0;
+    arthur_x_margin = margin * imagescalex;
+}
+
+
+void arthur_draw_room_image(int picnum) {
+    int x, y, width, height;
+
+    if (picnum == K_PIC_PARADE_AREA || picnum == K_PIC_AIR_SCENE) {
+        get_image_size(picnum, &width, &height);
+        showing_wide_arthur_room_image = true;
+    } else {
+        get_image_size(K_PIC_CHURCHYARD, &width, &height);
+        showing_wide_arthur_room_image = false;
+    }
+
+    x = ((hw_screenwidth - width) / 2.0);
+    y = arthur_pic_top_margin;
+    if (showing_wide_arthur_room_image)
+        y--;
+
+    if (graphics_type == kGraphicsTypeMacBW) {
+        y += 11;
+        x++;
+    } else {
+        y += 7;
+    }
+
+    if (is_arthur_stamp_image(picnum)) {
+        // All pictures have an offset (dummy) image. It usually is the one
+        // before the actual picture, i.e. picture index - 1, except for the one of
+        // the island door (K-PIC-ISLAND-DOOR is 158 and K-PIC-ISLAND-DOOR-OFF is 159.)
+        if (picnum == K_PIC_ISLAND_DOOR)
+            get_image_size(K_PIC_ISLAND_DOOR_OFF, &width, &height);
+        else
+            get_image_size(picnum - 1, &width, &height);
+
+        // The Amiga version of the stone image seems to have an incorrect offset
+        if (picnum == K_PIC_STONE_2 && graphics_type == kGraphicsTypeAmiga)
+            width -= 4;
+
+        x += width;
+        y += height;
+    } else if (!is_arthur_room_image(picnum)) {
+        return;
+    }
+
+    draw_to_pixmap_unscaled(picnum, x, y);
+}
+
+
+static void arthur_draw_map_image(int picnum, int x, int y) {
+    int x_margin;
+    get_image_size(K_PIC_BANNER_MARGIN, &x_margin, nullptr);
+    x += x_margin;
+    if (options.int_number == INTERP_MACINTOSH)
+        y--;
+    if (graphics_type != kGraphicsTypeApple2 && graphics_type != kGraphicsTypeMacBW){
+        if (picnum >= 138 || graphics_type == kGraphicsTypeCGA) {
+            y--;
+        }
+    }
+    draw_to_pixmap_unscaled(picnum, x, y);
+}
+
+enum kArthurWindowType {
+    K_WIN_NONE = 0,
+    K_WIN_INVT = 1,
+    K_WIN_DESC = 2,
+    K_WIN_STAT = 3,
+    K_WIN_MAP = 4,
+    K_WIN_PICT = 5
+};
+
+void arthur_sync_screenmode(void) {
+    kArthurWindowType window_type = (kArthurWindowType)get_global(ag.GL_WINDOW_TYPE);
+    switch (window_type) {
+        case K_WIN_NONE:
+            screenmode = MODE_NO_GRAPHICS;
+            break;
+        case K_WIN_INVT:
+            screenmode = MODE_INVENTORY;
+            break;
+        case K_WIN_DESC:
+            screenmode = MODE_ROOM_DESC;
+            break;
+        case K_WIN_STAT:
+            screenmode = MODE_STATUS;
+            break;
+        case K_WIN_MAP:
+            screenmode = MODE_MAP;
+            break;
+        case K_WIN_PICT:
+            screenmode = MODE_NORMAL;
+            break;
+    }
+}
+
+// Window 0 (S-TEXT) is the standard V6 text buffer window (V6_TEXT_BUFFER_WINDOW)
+// Window 1 (S-WINDOW) is the standard V6 status window (V6_STATUS_WINDOW)
+
+// Window 2 is the small room graphics window at top, not including banners (ARTHUR_ROOM_GRAPHIC_WIN)
+// Window 3 is the inverted error window at the bottom (ARTHUR_ERROR_WINDOW)
+
+// Windows 5 and 6 are left and right banners, but are only used when erasing
+// banner graphics. The banners are drawn to window S-FULL (7)
+
+// Window 7 (S-FULL) is the standard V6 fullscreen window (ARTHUR_GRAPHICS_BG)
+
+// Called on window_changed();
+void arthur_update_on_resize(void) {
+    image_needs_redraw = true;
+    adjust_arthur_top_margin();
+
+    glk_stylehint_set(wintype_TextGrid, style_Normal, stylehint_TextColor, user_selected_foreground);
+    glk_stylehint_set(wintype_TextGrid, style_Normal, stylehint_BackColor, user_selected_background);
+    glk_stylehint_set(wintype_TextGrid, style_Subheader, stylehint_TextColor, user_selected_foreground);
+    glk_stylehint_set(wintype_TextGrid, style_Subheader, stylehint_BackColor, user_selected_background);
+
+    if (ARTHUR_ROOM_GRAPHIC_WIN.id && ARTHUR_ROOM_GRAPHIC_WIN.id->type == wintype_TextGrid)
+        v6_delete_win(&ARTHUR_ROOM_GRAPHIC_WIN);
+
+    int screenheight = gscreenh;
+    if (ARTHUR_ERROR_WINDOW.id != nullptr) {
+        int error_window_height = get_global(ag.GL_AUTHOR_SIZE);
+        if (error_window_height == 0)
+            error_window_height = 1;
+        screenheight -= (gcellh * error_window_height + 2 * ggridmarginy);
+    }
+
+    if (screenmode == MODE_INITIAL_QUESTION)
+        return;
+
+    if (screenmode != MODE_SLIDESHOW) {
+        if (current_graphics_buf_win && screenmode != MODE_NORMAL) {
+            glk_window_set_background_color(current_graphics_buf_win, user_selected_background);
+            glk_window_clear(current_graphics_buf_win);
+        }
+        if (screenmode != MODE_NO_GRAPHICS) {
+            int x_margin = 0, y_margin = 0;
+            get_image_size(K_PIC_BANNER_MARGIN, &x_margin, &y_margin);
+
+            if (screenmode == MODE_MAP) {
+                ARTHUR_ROOM_GRAPHIC_WIN.y_origin = 0;
+                ARTHUR_ROOM_GRAPHIC_WIN.x_origin = x_margin;
+                ARTHUR_ROOM_GRAPHIC_WIN.x_size = hw_screenwidth - 2 * x_margin;
+            }
+
+            x_margin *= imagescalex;
+            y_margin *= imagescaley;
+
+            if (screenmode != MODE_HINTS) {
+                V6_STATUS_WINDOW.y_origin = arthur_text_top_margin;
+                win_setbgnd(V6_TEXT_BUFFER_WINDOW.id->peer, user_selected_background);
+            }
+
+            int width_in_chars = ((float)(gscreenw - 2 * x_margin) / gcellw);
+            V6_STATUS_WINDOW.x_size = width_in_chars * gcellw;
+            V6_STATUS_WINDOW.x_origin = (gscreenw - V6_STATUS_WINDOW.x_size) / 2;
+            if (graphics_type == kGraphicsTypeApple2) {
+                V6_STATUS_WINDOW.x_origin += imagescalex;
+            }
+
+            mainwin->x_origin = V6_STATUS_WINDOW.x_origin;
+            mainwin->x_size = V6_STATUS_WINDOW.x_size;
+
+            if (screenmode == MODE_HINTS) {
+                V6_STATUS_WINDOW.y_size = 3 * gcellh + 2 * ggridmarginy;
+                mainwin->y_origin = V6_STATUS_WINDOW.y_origin + V6_STATUS_WINDOW.y_size + gcellh;
+            } else {
+                V6_STATUS_WINDOW.y_size = gcellh + 2 * ggridmarginy;
+                mainwin->y_origin = V6_STATUS_WINDOW.y_origin + V6_STATUS_WINDOW.y_size;
+            }
+
+            mainwin->y_size = screenheight - mainwin->y_origin - 1;
+
+            v6_sizewin(&V6_STATUS_WINDOW);
+            v6_sizewin(mainwin);
+
+            if (screenmode == MODE_HINTS) {
+                redraw_hint_screen_on_resize();
+                glk_request_mouse_event(V6_TEXT_BUFFER_WINDOW.id);
+                glk_request_mouse_event(V6_STATUS_WINDOW.id);
+                return;
+            }
+
+            if (screenmode == MODE_STATUS || screenmode == MODE_INVENTORY || screenmode == MODE_ROOM_DESC) {
+                ARTHUR_ROOM_GRAPHIC_WIN.x_origin = V6_STATUS_WINDOW.x_origin;
+                ARTHUR_ROOM_GRAPHIC_WIN.x_size = V6_STATUS_WINDOW.x_size;
+                ARTHUR_ROOM_GRAPHIC_WIN.y_size = arthur_text_top_margin - 1;
+                glui32 wintype;
+                if (screenmode == MODE_ROOM_DESC) {
+                    wintype = wintype_TextBuffer;
+                } else {
+                    wintype = wintype_TextGrid;
+                }
+                if (ARTHUR_ROOM_GRAPHIC_WIN.id == nullptr || ARTHUR_ROOM_GRAPHIC_WIN.id->type != wintype) {
+                    if (ARTHUR_ROOM_GRAPHIC_WIN.id != nullptr) {
+                        gli_delete_window(ARTHUR_ROOM_GRAPHIC_WIN.id);
+                        ARTHUR_ROOM_GRAPHIC_WIN.id = nullptr;
+                    }
+                    v6_remap_win(&ARTHUR_ROOM_GRAPHIC_WIN, wintype, nullptr);
+                } else {
+                    v6_sizewin(&ARTHUR_ROOM_GRAPHIC_WIN);
+                }
+                win_setbgnd(ARTHUR_ROOM_GRAPHIC_WIN.id->peer, user_selected_background);
+            } else {
+                v6_delete_win(&ARTHUR_ROOM_GRAPHIC_WIN);
+            }
+
+            v6_get_and_sync_upperwin_size();
+
+            if (screenmode == MODE_NORMAL) {
+                clear_image_buffer();
+                internal_call_with_arg(pack_routine(ar.RT_UPDATE_PICT_WINDOW), 1);
+                draw_arthur_side_images(current_graphics_buf_win);
+                if (showing_wide_arthur_room_image)
+                    arthur_draw_room_image(current_picture);
+                flush_bitmap(current_graphics_buf_win);
+            } else if (screenmode == MODE_INVENTORY) {
+                internal_call_with_arg(pack_routine(ar.RT_UPDATE_INVT_WINDOW), 1);
+            } else if (screenmode == MODE_STATUS) {
+                internal_call_with_arg(pack_routine(ar.RT_UPDATE_STAT_WINDOW), 1);
+            } else if (screenmode == MODE_MAP) {
+                set_global(ag.GL_MAP_GRID_Y, 0);
+                internal_call_with_arg(pack_routine(ar.RT_UPDATE_MAP_WINDOW), 1);
+                flush_bitmap(current_graphics_buf_win);
+            }
+        } else {
+            v6_define_window(&V6_STATUS_WINDOW, 1, 1, gscreenw, gcellh + 2 * ggridmarginy);
+            v6_define_window(mainwin, 1, V6_STATUS_WINDOW.y_origin + V6_STATUS_WINDOW.y_size, gscreenw, screenheight - mainwin->y_origin - 1);
+            v6_delete_win(&ARTHUR_ROOM_GRAPHIC_WIN);
+        }
+
+        set_global(ag.UPDATE, 0);
+        internal_call(pack_routine(ar.UPDATE_STATUS_LINE));
+
+        if (ARTHUR_ERROR_WINDOW.id != nullptr) {
+            v6_define_window(&ARTHUR_ERROR_WINDOW, V6_TEXT_BUFFER_WINDOW.x_origin, screenheight + 1, V6_TEXT_BUFFER_WINDOW.x_size, gscreenh - screenheight);
+        }
+    } else {
+        // We are showing a fullscreen image
+        v6_define_window(mainwin, 1, 1, gscreenw, gscreenh);
+
+        glk_window_set_background_color(current_graphics_buf_win, user_selected_background);
+        win_sizewin(current_graphics_buf_win->peer, 0, 0, gscreenw, gscreenh);
+        glk_window_clear(current_graphics_buf_win);
+        if (last_slideshow_pic == K_PIC_SWORD_MERLIN) {
+            float scale = draw_centered_title_image(K_PIC_SWORD);
+            draw_centered_image(K_PIC_SWORD_MERLIN, scale, 0, 0);
+        } else {
+            draw_centered_title_image(last_slideshow_pic);
+        }
+    }
+}
+
+void arthur_move_cursor(int16_t y, int16_t x, winid_t win) {
+    x--;
+    y--;
+    if (x < 0) x = 0;
+    if (y < 0) y = 0;
+
+    glk_window_move_cursor(win, x, y);
+}
+
+void RT_UPDATE_PICT_WINDOW(void) {
+    if (screenmode == MODE_SLIDESHOW || screenmode == MODE_INITIAL_QUESTION) {
+        screenmode = MODE_NORMAL;
+        win_sizewin(graphics_fg_glk->peer, 0, 0, 0, 0);
+        current_graphics_buf_win = graphics_bg_glk;
+        windows[7].id = graphics_bg_glk;
+        arthur_update_on_resize();
+        v6_get_and_sync_upperwin_size();
+    }
+}
+
+void RT_UPDATE_INVT_WINDOW(void) {
+    screenmode = MODE_INVENTORY;
+    if (ARTHUR_ROOM_GRAPHIC_WIN.id) {
+        glk_set_window(ARTHUR_ROOM_GRAPHIC_WIN.id);
+        glk_set_style(style_Subheader);
+    }
+}
+
+void RT_UPDATE_STAT_WINDOW(void) {
+    screenmode = MODE_STATUS;
+}
+
+void RT_UPDATE_MAP_WINDOW(void) {
+    screenmode = MODE_MAP;
+    glk_request_mouse_event(graphics_bg_glk);
+}
+
+void RT_UPDATE_DESC_WINDOW(void) {
+    screenmode = MODE_ROOM_DESC;
+}
+
+void arthur_INIT_STATUS_LINE(void) {
+    arthur_update_on_resize();
+
+    int M;
+    if (!get_image_size(K_PIC_BANNER_MARGIN, &M, nullptr)) { // <PICINF ,K-PIC-BANNER-MARGIN ,K-WIN-TBL>
+        M = gcellw * 3;
+    }
+    int W = gscreenw - 2 * M;
+    int L = M + 1;
+
+    // Windows 5 and 6 are left and right banners, but are only used when erasing
+    // banner graphics. The actual banners are drawn to window 7 (S-FULL).
+    windows[5].y_origin = 1;
+    windows[5].x_origin = 1;
+    windows[5].y_size = gscreenh;
+    windows[5].x_size = M;
+
+    windows[6].y_origin = 1;
+    windows[6].x_origin = L + W;
+    windows[6].y_size = gscreenh;
+    windows[6].x_size = M;
+
+    // Window 7 (S-FULL) is the standard V6 fullscreen window
+    windows[7].y_origin = 1;
+    windows[7].x_origin = 1;
+    windows[7].y_size = gscreenh;
+    windows[7].x_size = gscreenw;
+
+    glk_set_window(V6_STATUS_WINDOW.id);
+    glk_window_move_cursor(V6_STATUS_WINDOW.id, 0, 0);
+
+    glui32 width;
+    glk_window_get_size(V6_STATUS_WINDOW.id, &width, nullptr);
+    garglk_set_reversevideo(1);
+    for (int i = 0; i < width; i++)
+        glk_put_char(' ');
+    garglk_set_reversevideo(0);
+    glk_set_window(V6_TEXT_BUFFER_WINDOW.id);
+
+    if (header.release > 41)
+        set_global(ag.GL_TIME_WIDTH, 0);
+    set_global(ag.GL_SL_HERE, 0);
+    set_global(ag.GL_SL_VEH, 0);
+    set_global(ag.GL_SL_HIDE, 0);
+    set_global(ag.GL_SL_TIME, 0);
+    set_global(ag.GL_SL_FORM, 0);
+}
+
+int count_lines(uint32_t table) {
+    int lines = 0;
+    for (uint16_t count = user_word(table); count != 0; count = user_word(table)) {
+        lines++;
+        table += 2 + count;
+    }
+    return lines;
+}
+
+void RT_AUTHOR_OFF(void) {
+
+    output_stream(-3, 0);
+
+    uint32_t addr = at.K_DIROUT_TBL;
+
+    if (get_global(fg_global_idx) == DEFAULT_COLOUR) {
+        glk_stylehint_clear(wintype_TextGrid, style_Normal, stylehint_BackColor);
+        glk_stylehint_clear(wintype_TextGrid, style_Normal, stylehint_TextColor);
+        glk_stylehint_set(wintype_TextGrid, style_Normal, stylehint_ReverseColor, 1);
+    } else {
+        glk_stylehint_set(wintype_TextGrid, style_Normal, stylehint_BackColor, user_selected_foreground);
+        glk_stylehint_set(wintype_TextGrid, style_Normal, stylehint_TextColor, user_selected_background);
+        glk_stylehint_set(wintype_TextGrid, style_Normal, stylehint_ReverseColor, 0);
+    }
+
+    ARTHUR_ERROR_WINDOW.fg_color = Color(Color::Mode::ANSI, get_global(fg_global_idx));
+    ARTHUR_ERROR_WINDOW.bg_color = Color(Color::Mode::ANSI, get_global(bg_global_idx));
+    ARTHUR_ERROR_WINDOW.style.reset(STYLE_REVERSE);
+    v6_delete_win(&ARTHUR_ERROR_WINDOW);
+
+    if (ARTHUR_ERROR_WINDOW.id == nullptr && !gli_zmachine_no_err_win)
+        ARTHUR_ERROR_WINDOW.id = gli_new_window(wintype_TextGrid, 0);
+
+    int lines;
+
+    if (header.release > 41) {
+        lines = count_lines(addr);
+    } else {
+        int width_in_chars = (V6_TEXT_BUFFER_WINDOW.x_size - 2 * ggridmarginx) / gcellw;
+        lines = user_word(addr) / width_in_chars + 1;
+        if (user_word(addr) % width_in_chars == 0)
+            lines--;
+    }
+
+    if (!gli_zmachine_no_err_win) {
+        set_global(ag.GL_AUTHOR_SIZE, lines);
+
+        int height = gcellh * lines + 2 * ggridmarginy;
+
+        v6_define_window(&ARTHUR_ERROR_WINDOW, V6_TEXT_BUFFER_WINDOW.x_origin, gscreenh - height + 1, V6_TEXT_BUFFER_WINDOW.x_size, height);
+
+        V6_TEXT_BUFFER_WINDOW.y_size = gscreenh - V6_TEXT_BUFFER_WINDOW.y_origin - height + 1;
+        v6_sizewin(&V6_TEXT_BUFFER_WINDOW);
+        glk_window_clear(ARTHUR_ERROR_WINDOW.id);
+        glk_set_window(ARTHUR_ERROR_WINDOW.id);
+    } else {
+        glk_set_window(V6_TEXT_BUFFER_WINDOW.id);
+    }
+
+    if (header.release > 41) {
+        for (uint16_t count = user_word(addr); count != 0; count = user_word(addr)) {
+            for (uint16_t i = 0; i < count; i++) {
+                put_char(user_byte(addr + 2 + i));
+            }
+            put_char(ZSCII_NEWLINE);
+
+            addr += 2 + count;
+        }
+    } else {
+        int number_of_letters = user_word(addr);
+        for (uint16_t count = 0; count < number_of_letters; count++) {
+            put_char(user_byte(addr + 2 + count));
+        }
+    }
+
+    glk_stylehint_set(wintype_TextGrid, style_Normal, stylehint_TextColor, user_selected_foreground);
+    glk_stylehint_set(wintype_TextGrid, style_Normal, stylehint_BackColor, user_selected_background);
+    glk_stylehint_clear(wintype_TextGrid, style_Normal, stylehint_ReverseColor);
+
+    glk_set_window(V6_TEXT_BUFFER_WINDOW.id);
+}
+
+bool arthur_display_picture(glui32 picnum, glsi32 x, glsi32 y) {
+
+    // Fullscreen images
+    if ((picnum >= 1 && picnum <= 3) || picnum == K_PIC_ENDGAME || picnum == K_PIC_ANGRY_DEMON) {
+        if (current_graphics_buf_win == nullptr || current_graphics_buf_win == graphics_bg_glk) {
+            current_graphics_buf_win = graphics_fg_glk;
+        }
+        
+        glk_window_set_background_color(current_graphics_buf_win, user_selected_background);
+        win_sizewin(current_graphics_buf_win->peer, 0, 0, gscreenw, gscreenh);
+        screenmode = MODE_SLIDESHOW;
+        glk_request_mouse_event(current_graphics_buf_win);
+        if (picnum != K_PIC_SWORD_MERLIN) {
+            glk_window_clear(current_graphics_buf_win);
+            draw_centered_title_image(picnum);
+        } else {
+            float scale = draw_centered_title_image(K_PIC_SWORD);
+            draw_centered_image(K_PIC_SWORD_MERLIN, scale, 0, 0);
+        }
+        return true;
+    }
+
+    else if (current_graphics_buf_win == nullptr) {
+        current_graphics_buf_win = graphics_bg_glk;
+    }
+
+
+    // Room images
+    if (is_arthur_room_image(picnum) || is_arthur_stamp_image(picnum)) { // Pictures 106-149 are map images
+        screenmode = MODE_NORMAL;
+        ensure_pixmap(current_graphics_buf_win);
+        arthur_draw_room_image(picnum);
+        return true;
+    } else if (is_arthur_map_image(picnum)) {
+        screenmode = MODE_MAP;
+        if (picnum == K_MAP_SCROLL) {// map background
+            glk_request_mouse_event(graphics_bg_glk);
+        } else {
+            arthur_draw_map_image(picnum, x, y);
+            return true;
+        }
+    } else if (picnum == K_PIC_BANNER) { // Border image, drawn in flush_image_buffer()
+        screenmode = MODE_NORMAL;
+        return true;
+    }
+
+    draw_to_buffer(current_graphics_buf_win, picnum, x, y);
+    return true;
+}
+
+void arthur_erase_window(int16_t index) {
+    if (!is_spatterlight_arthur)
+        return;
+
+    switch (index) {
+        case -1:
+            if (screenmode == MODE_SLIDESHOW) {
+                clear_image_buffer();
+                glk_window_set_background_color(graphics_bg_glk, user_selected_background);
+                glk_window_clear(graphics_bg_glk);
+                glk_window_set_background_color(graphics_fg_glk, user_selected_background);
+                glk_window_clear(graphics_fg_glk);
+                if (last_slideshow_pic == K_PIC_ANGRY_DEMON) {
+                    screenmode = MODE_NORMAL;
+                } else {
+                    screenmode = MODE_INITIAL_QUESTION;
+                }
+                current_graphics_buf_win = nullptr;
+                win_sizewin(graphics_fg_glk->peer, 0, 0, 0, 0);
+                if (last_slideshow_pic == K_PIC_ENDGAME) {
+                    glk_window_clear(graphics_bg_glk);
+                    win_sizewin(V6_STATUS_WINDOW.id->peer, 0, 0, 0, 0);
+                    v6_delete_win(&ARTHUR_ROOM_GRAPHIC_WIN);
+                    win_sizewin(V6_TEXT_BUFFER_WINDOW.id->peer, 0, 0, gscreenw, gscreenh);
+                }
+
+            } else if (screenmode == MODE_INITIAL_QUESTION) {
+                screenmode = MODE_SLIDESHOW;
+            }
+            v6_delete_win(&ARTHUR_ROOM_GRAPHIC_WIN);
+            break;
+        case 2:
+            clear_image_buffer();
+            break;
+        case 3:
+            v6_delete_win(&ARTHUR_ERROR_WINDOW);
+            break;
+        default:
+            break;
+    }
+}
+
+#pragma mark Restoring
+
+void stash_arthur_state(library_state_data *dat) {
+
+    if (!dat)
+        return;
+
+    if (current_graphics_buf_win)
+        dat->current_graphics_win_tag = current_graphics_buf_win->tag;
+    if (graphics_fg_glk)
+        dat->graphics_fg_tag = graphics_fg_glk->tag;
+    if (stored_bufferwin)
+        dat->stored_lower_tag = stored_bufferwin->tag;
+    dat->slideshow_pic = last_slideshow_pic;
+}
+
+void recover_arthur_state(library_state_data *dat) {
+
+    if (!dat)
+        return;
+
+    current_graphics_buf_win = gli_window_for_tag(dat->current_graphics_win_tag);
+    graphics_fg_glk = gli_window_for_tag(dat->graphics_fg_tag);
+    stored_bufferwin = gli_window_for_tag(dat->stored_lower_tag);
+    last_slideshow_pic = dat->slideshow_pic;
+}
+
+void update_monochrome_colours(void);
+
+void after_V_COLOR(void) {
+    uint8_t fg = get_global(fg_global_idx);
+    uint8_t bg = get_global(bg_global_idx);
+
+    update_user_defined_colours();
+
+    for (auto &window : windows) {
+        // These will already be correctly set unless we are called from the after restore routine
+        window.fg_color = Color(Color::Mode::ANSI, fg);
+        window.bg_color = Color(Color::Mode::ANSI, bg);
+        winid_t glkwin = window.id;
+        if (glkwin != nullptr) {
+            if (glkwin->type == wintype_Graphics) {
+                glk_window_set_background_color(glkwin, user_selected_background);
+                glk_window_clear(glkwin);
+            } else {
+                if (glkwin->type == wintype_TextBuffer) {
+                    win_setbgnd(glkwin->peer, user_selected_background);
+                }
+
+                glk_set_window(glkwin);
+
+                // Colours may be set to default (1) if this is called from the after restore routine
+                glsi32 zcolfg, zcolbg;
+                if (fg == DEFAULT_COLOUR)
+                    zcolfg = zcolor_Default;
+                else
+                    zcolfg = user_selected_foreground;
+
+                if (bg == DEFAULT_COLOUR)
+                    zcolbg = zcolor_Default;
+                else
+                    zcolbg = user_selected_background;
+
+                garglk_set_zcolors(zcolfg, zcolbg);
+            }
+        }
+    }
+    update_monochrome_colours();
+    arthur_update_on_resize();
+}
+
+void arthur_update_after_restore(void) {
+    arthur_sync_screenmode();
+    after_V_COLOR();
+}
+
+void arthur_close_and_reopen_front_graphics_window(void) {
+    if (graphics_fg_glk) {
+        if (current_graphics_buf_win == graphics_fg_glk) {
+            current_graphics_buf_win = nullptr;
+        }
+        gli_delete_window(graphics_fg_glk);
+    }
+    graphics_fg_glk = gli_new_window(wintype_Graphics, 0);
+    if (screenmode == MODE_SLIDESHOW) {
+        win_sizewin(graphics_fg_glk->peer, 0, 0, gscreenw, gscreenh);
+        current_graphics_buf_win = graphics_fg_glk;
+        glk_request_mouse_event(graphics_fg_glk);
+    } else {
+        win_sizewin(graphics_fg_glk->peer, 0, 0, 0, 0);
+        if (screenmode == MODE_INITIAL_QUESTION) {
+            current_graphics_buf_win = nullptr;
+        } else {
+            current_graphics_buf_win = graphics_bg_glk;
+        }
+    }
+}
+
+void arthur_update_after_autorestore(void) {
+    update_user_defined_colours();
+    arthur_close_and_reopen_front_graphics_window();
+    uint8_t fg = get_global(fg_global_idx);
+    uint8_t bg = get_global(bg_global_idx);
+
+    for (auto &window : windows) {
+        window.fg_color = Color(Color::Mode::ANSI, fg);
+        window.bg_color = Color(Color::Mode::ANSI, bg);
+    }
+
+    if (current_graphics_buf_win) {
+        glk_window_set_background_color(current_graphics_buf_win, user_selected_background);
+        glk_window_clear(current_graphics_buf_win);
+    }
+
+    window_change();
+}
+
+struct HotKeyDict {
+    kArthurWindowType wintype;
+    V6ScreenMode mode;
+};
+
+static std::unordered_map<uint8_t, HotKeyDict> hotkeys = {
+    { ZSCII_F1, {K_WIN_PICT, MODE_NORMAL}      },
+    { ZSCII_F2, {K_WIN_MAP,  MODE_MAP}         },
+    { ZSCII_F3, {K_WIN_INVT, MODE_INVENTORY}   },
+    { ZSCII_F4, {K_WIN_STAT, MODE_STATUS}      },
+    { ZSCII_F5, {K_WIN_DESC, MODE_ROOM_DESC}   },
+    { ZSCII_F6, {K_WIN_NONE, MODE_NO_GRAPHICS} },
+};
+
+void RT_HOT_KEY(void) {
+    if (screenmode == MODE_HINTS || screenmode == MODE_SLIDESHOW)
+        return;
+
+    HotKeyDict hotkey = hotkeys[variable(1)];
+
+    kArthurWindowType oldwintype = (kArthurWindowType)get_global(ag.GL_WINDOW_TYPE);
+    kArthurWindowType newwintype = hotkey.wintype;
+
+    if (oldwintype != newwintype) {
+        set_global(ag.GL_WINDOW_TYPE, newwintype);
+        screenmode = hotkey.mode;
+        arthur_update_on_resize();
+    }
+}
+
+bool arthur_autorestore_internal_read_char_hacks(void) {
+    if (screenmode == MODE_HINTS) {
+        return true;
+    }
+    return false;
+}
+
+void ARTHUR_UPDATE_STATUS_LINE(void) {
+    // We must always redraw the entire status bar,
+    // or stray letters will be left behind
+
+    glk_set_window(V6_STATUS_WINDOW.id);
+    glk_window_move_cursor(V6_STATUS_WINDOW.id, 0, 0);
+    glui32 width;
+    glk_window_get_size(V6_STATUS_WINDOW.id, &width, nullptr);
+    garglk_set_reversevideo(1);
+    for (int i = 0; i < width; i++)
+        glk_put_char(' ');
+    set_global(ag.GL_SL_FORM, 99);
+    set_global(ag.GL_SL_VEH, 0);
+    set_global(ag.GL_SL_HERE, 0);
+    set_global(ag.GL_SL_HIDE, 0);
+    set_global(ag.GL_SL_TIME, 0);
+}
+
+void UPDATE_STATUS_LINE(void) {}
+void RT_TH_EXCALIBUR(void) {}

--- a/terps/bocfel/z6/arthur.hpp
+++ b/terps/bocfel/z6/arthur.hpp
@@ -1,0 +1,88 @@
+//
+//  arthur.hpp
+//  bocfel6
+//
+//  Created by Administrator on 2023-07-18.
+//
+
+#ifndef arthur_hpp
+#define arthur_hpp
+
+extern "C" {
+#include "glk.h"
+#include "glkimp.h"
+#include "spatterlight-autosave.h"
+}
+
+#include <stdio.h>
+bool is_arthur_map_image(int picnum);
+
+void adjust_arthur_top_margin(void);
+void arthur_update_on_resize(void);
+void arthur_adjust_windows(void);
+void arthur_erase_window(int16_t index);
+void arthur_move_cursor(int16_t y, int16_t x, winid_t win);
+
+void RT_UPDATE_PICT_WINDOW(void);
+void RT_UPDATE_INVT_WINDOW(void);
+void RT_UPDATE_STAT_WINDOW(void);
+void RT_UPDATE_MAP_WINDOW(void);
+void RT_UPDATE_DESC_WINDOW(void);
+void RT_HOT_KEY(void);
+void after_V_COLOR(void);
+
+void ARTHUR_UPDATE_STATUS_LINE(void);
+void arthur_INIT_STATUS_LINE(void);
+void RT_AUTHOR_OFF(void);
+void RT_TH_EXCALIBUR(void);
+
+bool arthur_display_picture(glui32 picnum, glsi32 x, glsi32 y);
+void arthur_draw_room_image(int picnum);
+
+void arthur_update_after_restore(void);
+void arthur_update_after_autorestore(void);
+
+bool arthur_autorestore_internal_read_char_hacks(void);
+void arthur_close_and_reopen_front_graphics_window(void);
+
+void arthur_sync_screenmode(void);
+
+void stash_arthur_state(library_state_data *dat);
+void recover_arthur_state(library_state_data *dat);
+
+typedef struct ArthurGlobals {
+    uint8_t UPDATE; // G0e•
+    uint8_t NAME_COLUMN; // Ga3•
+    uint8_t GL_MAP_GRID_Y; // Ga3•
+    uint8_t GL_WINDOW_TYPE; // Ga3•
+    uint8_t GL_AUTHOR_SIZE;
+    uint8_t GL_TIME_WIDTH;
+    uint8_t GL_SL_HERE;
+    uint8_t GL_SL_VEH;
+    uint8_t GL_SL_HIDE;
+    uint8_t GL_SL_TIME;
+    uint8_t GL_SL_FORM;
+} ArthurGlobals;
+
+extern ArthurGlobals ag;
+
+typedef struct ArthurRoutines {
+    uint32_t UPDATE_STATUS_LINE;
+    uint32_t RT_UPDATE_PICT_WINDOW;
+    uint32_t RT_UPDATE_INVT_WINDOW;
+    uint32_t RT_UPDATE_STAT_WINDOW;
+    uint32_t RT_UPDATE_MAP_WINDOW;
+    uint32_t RT_UPDATE_DESC_WINDOW;
+    uint32_t RT_SEE_QST;
+} ArthurRoutines;
+
+extern ArthurRoutines ar;
+
+typedef struct ArthurTables {
+    uint16_t K_DIROUT_TBL;
+    uint16_t K_HINT_ITEMS;
+} ArthurTables;
+
+extern ArthurTables at;
+
+#endif /* arthur_hpp */

--- a/terps/bocfel/z6/decompress_amiga.cpp
+++ b/terps/bocfel/z6/decompress_amiga.cpp
@@ -41,7 +41,7 @@ uint8_t *decompress_amiga(ImageStruct *image) {
                     j++;
 
                 if (j > image->datasize) {
-                    fprintf(stderr, "Read %d bytes, which is out of range (expected data size: %zu). Something is wrong.\n", j, image->datasize);
+                    fprintf(stderr, "decompress_amiga: Read %d bytes, which is out of range (expected data size: %zu). Something is wrong.\n", j, image->datasize);
                     free(buffer);
                     return nullptr;
                 }

--- a/terps/bocfel/z6/draw_image.hpp
+++ b/terps/bocfel/z6/draw_image.hpp
@@ -30,11 +30,14 @@ void draw_to_pixmap_unscaled(int image, int x, int y);
 void draw_to_pixmap_unscaled_flipped(int image, int x, int y);
 void ensure_pixmap(winid_t winid);
 void draw_arthur_side_images(winid_t winid);
-void draw_centered_title_image(int picnum);
+void draw_centered_image(int picnum, float scale, int width, int height);
+float draw_centered_title_image(int picnum);
 void draw_rectangle_on_bitmap(glui32 color, int x, int y, int width, int height);
 
 extern int last_slideshow_pic;
 extern int32_t monochrome_black;
 extern int32_t monochrome_white;
+
+extern bool image_needs_redraw;
 
 #endif /* draw_image_hpp */

--- a/terps/bocfel/z6/entrypoints.cpp
+++ b/terps/bocfel/z6/entrypoints.cpp
@@ -9,9 +9,13 @@
 #include "memory.h"
 #include "dict.h"
 
+#include "arthur.hpp"
 #include "journey.hpp"
+#include "v6_shared.hpp"
 
 #include "entrypoints.hpp"
+
+uint8_t fg_global_idx = 0, bg_global_idx = 0;
 
 struct EntryPoint {
     Game game;
@@ -26,6 +30,182 @@ struct EntryPoint {
 #define WILDCARD 0xf8
 
 static std::vector<EntryPoint> entrypoints = {
+
+#pragma mark Arthur
+
+    {
+        Game::Arthur,
+        "Arthur INIT-STATUS-LINE",
+        { 0x41, WILDCARD, 0x00, 0x71, 0x54  },
+        0,
+        0,
+        true,
+        arthur_INIT_STATUS_LINE,
+    },
+
+    {
+        Game::Arthur,
+        "UPDATE-STATUS-LINE",
+        { 0xeb, 0x7f, 0x01, 0xf1, 0x7f, 0x01 },
+        0,
+        0,
+        false,
+        ARTHUR_UPDATE_STATUS_LINE
+    },
+
+    {
+        Game::Arthur,
+        "RT-AUTHOR-OFF",
+        { 0xf3, 0x3f, 0xff, 0xfd, 0x43, WILDCARD, 0x00, 0x45},
+        0,
+        0,
+        true,
+        RT_AUTHOR_OFF
+    },
+
+    {
+        Game::Arthur,
+        "V-COLOR",
+        { 0x41, WILDCARD, 0x03, 0x00, WILDCARD, 0x88, WILDCARD, WILDCARD, 0x00 },
+        0,
+        0,
+        false,
+        V_COLOR
+    },
+
+    {
+        Game::Arthur,
+        "after V-COLOR",
+        {},
+        0,
+        0,
+        false,
+        after_V_COLOR
+    },
+
+    {
+        Game::Arthur,
+        "RT-HOT-KEY",
+        {0xff, 0x7f, 0x02, 0xc7, 0xcd, 0x4f, 0x02, WILDCARD, WILDCARD, 0xff, 0x7f, 0x03, 0xc5 },
+        0,
+        0,
+        true,
+        RT_HOT_KEY
+    },
+
+    {
+        Game::Arthur,
+        "RT-HOT-KEY alt",
+        {0xff, 0x7f, 0x02, 0xc7, 0xcd, 0x4f, 0x02, WILDCARD, WILDCARD, 0x41, 0x01, 0x85, 0x52 },
+        0,
+        0,
+        true,
+        RT_HOT_KEY
+    },
+
+    {
+        Game::Arthur,
+        "RT-UPDATE-STAT-WINDOW",
+        { 0xbe, 0x12, 0x57, 0x02, 0x01, 0x02, 0xa0 },
+        0,
+        0,
+        false,
+        RT_UPDATE_STAT_WINDOW
+    },
+
+    {
+        Game::Arthur,
+        "RT-UPDATE-INVT-WINDOW",
+        { 0xeb, 0x7f, 0x02, 0xbe, 0x12, 0x57, 0x02, 0x01, 0x02, 0xbe },
+        0,
+        0,
+        false,
+        RT_UPDATE_INVT_WINDOW
+    },
+
+    {
+        Game::Arthur,
+        "RT-UPDATE-DESC-WINDOW",
+        { 0xeb, 0x7f, 0x02, 0xbe, 0x12, 0x57, 0x02, 0x01, 0x01, 0xa0, 0x01, 0x4a},
+        0,
+        0,
+        false,
+        RT_UPDATE_DESC_WINDOW
+    },
+
+    {
+        Game::Arthur,
+        "RT-UPDATE-MAP-WINDOW",
+        { 0xEB, 0x7F, 0x02, 0xBE, 0x12, 0x57, 0x02, 0x01, 0x02, 0xa0 },
+        -0x16,
+        0,
+        false,
+        RT_UPDATE_MAP_WINDOW
+    },
+
+    {
+        Game::Arthur,
+        "RT-UPDATE-PICT-WINDOW",
+        { 0xeb, 0x7f, 0x02, 0xbe, 0x12, 0x57, 0x02, 0x01, 0x02, 0x41 },
+        0,
+        0,
+        false,
+        RT_UPDATE_PICT_WINDOW
+    },
+
+    {
+        Game::Arthur,
+        "RT-TH-EXCALIBUR",
+        { 0x54, 0x00, 0x01, 0x00, 0xef, 0xaf, 0x04, 0x00, 0xf1, 0x7f, 0x02 },
+        0,
+        0,
+        false,
+        RT_TH_EXCALIBUR
+    },
+
+    {
+        Game::Arthur,
+        "DO-HINTS",
+        { 0xf1, 0x7f, 0x00, 0xef, 0x1f, 0xff, 0xff, 0x00,  0x88, WILDCARD, WILDCARD, 0x02},
+        0,
+        0,
+        true,
+        DO_HINTS
+    },
+
+
+    {
+        Game::Arthur,
+        "DO-HINTS alt",
+        { 0xf1, 0x7f, 0x00, 0x88, WILDCARD, WILDCARD, 0x02, 0xbe, 0x12, 0x57, 0x00, 0x01, 0x02 },
+        0,
+        0,
+        true,
+        DO_HINTS
+    },
+
+    {
+        Game::Arthur,
+        "DISPLAY-HINT",
+        { 0xf1, 0x7f, 0x00, 0xed, 0x7f, 0x00, 0xeb, 0x7f, 0x01, 0xf9},
+        0,
+        0,
+        false,
+        DISPLAY_HINT
+    },
+
+    {
+        Game::Arthur,
+        "RT-SEE-QST",
+        { 0xa0, 0x01, 0xc1, 0x22, 0x00, 0x01, 0x48 },
+        0,
+        0,
+        false,
+        RT_SEE_QST
+    },
+
+#pragma mark Journey
+
     {
         Game::Journey,
         "WCENTER",
@@ -404,7 +584,135 @@ int32_t find_16_bit_values_in_pattern(std::vector<uint8_t> pattern, std::vector<
     return last_match_offset;
 }
 
-void find_globals(void) {
+static uint32_t end_of_color_addr = 0;
+
+void find_arthur_globals(void) {
+    int start = 0;
+    for (auto &entrypoint : entrypoints) {
+
+        if (entrypoint.fn == V_COLOR && entrypoint.found_at_address != 0) {
+            start = find_globals_in_pattern({ 0x0d, WILDCARD, 0x09, 0x0d, WILDCARD, 0x02}, { &bg_global_idx, &fg_global_idx }, entrypoint.found_at_address, 300);
+            if (start == -1) {
+                fprintf(stderr, "Error! Could not find color globals!\n");
+            } else {
+                fprintf(stderr, "Global index of fg: 0x%x Global index of bg: 0x%x\n", fg_global_idx, bg_global_idx);
+                start = find_pattern_in_mem({0xb8}, start, 200);
+                if (start != -1) {
+                    end_of_color_addr = start;
+                    fprintf(stderr, "Found return from routine V_COLOR at address 0x%x\n", end_of_color_addr);
+                }
+            }
+        } else if (entrypoint.fn == after_V_COLOR && end_of_color_addr != 0) {
+            entrypoint.found_at_address = end_of_color_addr;
+            fprintf(stderr, "after_V_COLOR at address 0x%x\n", entrypoint.found_at_address);
+        } else if (entrypoint.fn == arthur_INIT_STATUS_LINE && entrypoint.found_at_address != 0) {
+            start = find_globals_in_pattern({0xb0, WILDCARD, 0x00, 0x71}, {&ag.GL_WINDOW_TYPE}, entrypoint.found_at_address, 100);
+            if (start == -1) {
+                fprintf(stderr, "Error! Did not find ag.GL_WINDOW_TYPE!\n");
+                start = entrypoint.found_at_address;
+            }
+
+            start = find_globals_in_pattern({0xf1, 0x7f, 0x00, 0x0d, 0x56, 0x00, 0xef, 0x5f, 0x01, 0x01}, {&ag.GL_TIME_WIDTH }, start, 300);
+            if (start == -1) {
+                fprintf(stderr, "Error! Did not find ag.GL_TIME_WIDTH\n");
+                start = entrypoint.found_at_address;
+            }
+
+            start = find_globals_in_pattern({0xef, 0x5f, 0x01, 0x01, 0xeb, 0x7f, 0x00,
+                0x0d, WILDCARD, 0x00,
+                0x0d, WILDCARD, 0x00,
+                0x0d, WILDCARD, 0x00,
+                0x0d, WILDCARD, 0x00,
+                0x0d, WILDCARD, 0x00,
+                0xb0}, {&ag.GL_SL_HERE, &ag.GL_SL_VEH, &ag.GL_SL_HIDE, &ag.GL_SL_TIME, &ag.GL_SL_FORM }, start, 300);
+
+            if (start == -1) {
+                fprintf(stderr, "Error! Did not find global in pattern!\n");
+            }
+
+
+        } else if (entrypoint.fn == ARTHUR_UPDATE_STATUS_LINE && entrypoint.found_at_address != 0) {
+            ar.UPDATE_STATUS_LINE = entrypoint.found_at_address - 1;
+            ag.UPDATE = memory[ar.UPDATE_STATUS_LINE + 0xd] - 0x10;
+        } else if (entrypoint.fn == RT_UPDATE_PICT_WINDOW && entrypoint.found_at_address != 0) {
+            ar.RT_UPDATE_PICT_WINDOW = entrypoint.found_at_address - 1;
+        } else if (entrypoint.fn == RT_TH_EXCALIBUR && entrypoint.found_at_address != 0) {
+            start = find_pattern_in_mem({0xf1, 0x7f, 0x02}, entrypoint.found_at_address, 300);
+            if (start != -1) {
+                // Patch <HLIGHT ,H-BOLD> to bold fixed-width, which we have
+                // mapped to style_User1, (set to bold, centered text) which
+                // matches the style of the original centered "THE END" text.
+
+                memory[start + 2] = 0x0a;
+            }
+        } else if (entrypoint.fn == RT_UPDATE_INVT_WINDOW && entrypoint.found_at_address != 0) {
+            ar.RT_UPDATE_INVT_WINDOW = entrypoint.found_at_address - 1;
+
+            // Patch to to fix second vertical bar not being drawn at certain sizes.
+            // The purpose of the original code seems to be to avoid drawing at third bar at the right edge
+            // but instead it skips the second bar if the window width in characters is evenly divisible by 3.
+            // Not sure if it is broken in the original as well or if it is due to us measuring window width
+            // differently.
+
+            // We just patch the line that adds 1 to the width to subtract 1 instead.
+
+            // ADD (SP)+,#01 -> -(SP) becomes
+            // SUB (SP)+,#01 -> -(SP)
+            start = find_pattern_in_mem({0x54, 0x00, 0x01, 0x00}, entrypoint.found_at_address, 300);
+            if (start != -1) {
+                store_byte(start, 0x55);
+            }
+
+        } else if (entrypoint.fn == RT_UPDATE_STAT_WINDOW && entrypoint.found_at_address != 0) {
+            ar.RT_UPDATE_STAT_WINDOW = entrypoint.found_at_address - 1;
+        } else if (entrypoint.fn == RT_UPDATE_DESC_WINDOW && entrypoint.found_at_address != 0) {
+            ar.RT_UPDATE_DESC_WINDOW = entrypoint.found_at_address - 1;
+        } else if (entrypoint.fn == RT_UPDATE_MAP_WINDOW && entrypoint.found_at_address != 0) {
+            ar.RT_UPDATE_MAP_WINDOW = entrypoint.found_at_address - 1;
+            find_globals_in_pattern({0xa0, WILDCARD, 0x55, 0xbe, 0x06}, {&ag.GL_MAP_GRID_Y}, entrypoint.found_at_address, 10);
+        } else if (entrypoint.fn == RT_AUTHOR_OFF && entrypoint.found_at_address != 0) {
+            start = find_globals_in_pattern({0x3f, 0xff, 0xfd, 0x43, WILDCARD, 0x00, 0x45}, {&ag.GL_AUTHOR_SIZE}, entrypoint.found_at_address, 100);
+            if (start == -1) {
+                fprintf(stderr, "ERROR: Could not find ag.GL_AUTHOR_SIZE!!\n");
+            } else {
+                fprintf(stderr, "ag.GL_AUTHOR_SIZE = 0x%x\n", ag.GL_AUTHOR_SIZE);
+            }
+            start = find_16_bit_values_in_pattern({ 0xd9, 0x0f, WILDCARD, WILDCARD, WILDCARD, WILDCARD }, { &at.K_DIROUT_TBL, &at.K_DIROUT_TBL, &at.K_DIROUT_TBL }, start, 100);
+            if (start == -1) {
+                fprintf(stderr, "ERROR: Could not find at.K_DIROUT_TBL!!\n");
+            } else {
+                fprintf(stderr, "at.K_DIROUT_TBL = 0x%x\n", at.K_DIROUT_TBL);
+            }
+        } else if (entrypoint.fn == DO_HINTS && entrypoint.found_at_address != 0) {
+            start = find_16_bit_values_in_pattern({ 0xf3, 0x3f, 0xff, 0xfd, 0xcd, 0x4f, WILDCARD, WILDCARD, WILDCARD, 0xcf, 0x1f, WILDCARD, WILDCARD }, { &hints_table_addr, &hints_table_addr, &hints_table_addr }, entrypoint.found_at_address, 300);
+            if (start != -1) {
+                fprintf(stderr, "hints_table_addr = 0x%x\n", hints_table_addr);
+                start = find_16_bit_values_in_pattern({0xd4, 0x1f, WILDCARD, WILDCARD, 0x02, 0x09, 0xcf, 0x1f, WILDCARD, WILDCARD, 0x00, 0x00}, {&at.K_HINT_ITEMS, &at.K_HINT_ITEMS}, start, 300);
+                if (start != -1) {
+                    fprintf(stderr, "at.K_HINT_ITEMS = 0x%x\n", at.K_HINT_ITEMS);
+                    start = find_globals_in_pattern({0xf7, 0xab, WILDCARD, 0x09, 0x00, 0x04, 0xc2}, {&hint_chapter_global_idx}, start, 100);
+                    if (start != -1) {
+                        fprintf(stderr, "hint_chapter_global_idx = 0x%x\n", hint_chapter_global_idx);
+                        start = find_globals_in_pattern({0x2d, 0x04, 0x07, 0xda, 0x2f, WILDCARD, WILDCARD, 0x04, 0x0d, WILDCARD, 0x01 }, {&hint_quest_global_idx, &hint_quest_global_idx, &hint_quest_global_idx}, start, 200);
+                        if (start != -1) {
+                            fprintf(stderr, "hint_quest_global_idx = 0x%x\n", hint_quest_global_idx);
+                        }
+                    }
+                }
+            }
+
+        } else if (entrypoint.fn == DISPLAY_HINT && entrypoint.found_at_address != 0) {
+            start = find_16_bit_values_in_pattern({ 0x01, 0x00, 0xcf, 0x2f, WILDCARD, WILDCARD, 0x00, 0x04  }, { &seen_hints_table_addr }, entrypoint.found_at_address, 300);
+            if (start != -1) {
+                fprintf(stderr, "seen_hints_table_addr = 0x%x\n", seen_hints_table_addr);
+            }
+        } else if (entrypoint.fn == RT_SEE_QST && entrypoint.found_at_address != 0) {
+            ar.RT_SEE_QST = entrypoint.found_at_address - 1;
+        }
+    }
+}
+
+void find_journey_globals(void) {
     for (auto &entrypoint : entrypoints) {
         if (entrypoint.fn == BOLD_PARTY_CURSOR && entrypoint.found_at_address != 0) {
 
@@ -511,7 +819,7 @@ void find_globals(void) {
 
             offset = find_values_in_pattern({ 0xed, 0x7f, WILDCARD, 0xb0}, {&ja.buffer_window_index}, entrypoint.found_at_address, 500);
             if (offset == -1) {
-                fprintf(stderr, "Error!\n");
+                fprintf(stderr, "Error! Did not find values in pattern!\n");
                 offset = entrypoint.found_at_address;
             }
             for (int i = offset; i < memory_size - 12; i++) {
@@ -608,6 +916,7 @@ void find_globals(void) {
         } else if (entrypoint.fn == REFRESH_CHARACTER_COMMAND_AREA && entrypoint.found_at_address != 0) {
             store_byte(entrypoint.found_at_address, 0xab);
             store_byte(entrypoint.found_at_address + 1, 0x01);
+        // Patch out repeated words when listing essences and reagents in later version when screen is narrow
         }  else if (entrypoint.fn == TELL_AMOUNTS && entrypoint.found_at_address != 0 && header.release >= 51) {
             uint32_t offset = entrypoint.found_at_address;
             store_byte(offset + 4, 0xb4);
@@ -627,28 +936,40 @@ void find_entrypoints(void) {
 
     for (auto &entrypoint : entrypoints) {
         if (is_game(entrypoint.game)) {
+            fprintf(stderr, "Looking for entrypoint %s\n", entrypoint.title.c_str());
             if (entrypoint.pattern.size()) {
                 int32_t offset = find_pattern_in_mem(entrypoint.pattern, start, end - start);
                 if (offset != -1) {
                     entrypoint.found_at_address = offset + entrypoint.offset;
                     start = entrypoint.found_at_address;
+                    fprintf(stderr, "Found routine %s at offset 0x%04x\n", entrypoint.title.c_str(), start);
                     if (entrypoint.stub_original) {
                         // Overwrite original byte with rtrue;
                         store_byte(entrypoint.found_at_address, 0xb0);
                     }
+                } else {
+                    fprintf(stderr, "Did not find it!\n");
                 }
+            } else {
+                fprintf(stderr, "Did not find it! (No pattern)\n");
             }
         }
     }
 
-    find_globals();
+    if (is_spatterlight_arthur)
+        find_arthur_globals();
+    else
+        find_journey_globals();
 }
 
 
 void check_entrypoints(uint32_t pc) {
     for (auto &entrypoint : entrypoints) {
-        if (is_game(entrypoint.game) && pc == entrypoint.found_at_address) {
+        if (pc == entrypoint.found_at_address) {
             (entrypoint.fn)();
+        }
+        if (entrypoint.found_at_address > pc) {
+            break;
         }
     }
 }

--- a/terps/bocfel/z6/entrypoints.hpp
+++ b/terps/bocfel/z6/entrypoints.hpp
@@ -13,6 +13,6 @@
 void find_entrypoints(void);
 void check_entrypoints(uint32_t pc);
 
-//extern uint8_t fg_global_idx, bg_global_idx;
+extern uint8_t fg_global_idx, bg_global_idx;
 
 #endif /* entrypoints_hpp */

--- a/terps/bocfel/z6/find_graphics_files.cpp
+++ b/terps/bocfel/z6/find_graphics_files.cpp
@@ -20,6 +20,9 @@ extern "C" {
 
 extern strid_t active_blorb_file_stream;
 
+extern bool is_spatterlight_journey;
+extern bool is_spatterlight_arthur;
+
 std::array<std::string, 7> found_graphics_files;
 
 // Look for the following files: filename.blb/.blorb, filename.MG1/.EG1/.EG2/.CG1, "pic.data", "cpic.data"
@@ -346,7 +349,11 @@ void find_and_load_z6_graphics(void) {
     size_t dotpos = file_name.rfind('.');
 
     if (delimiterpos != std::string::npos) {
-        file_name.replace(delimiterpos, dotpos - delimiterpos, "/journey");
+        if (is_spatterlight_journey) {
+            file_name.replace(delimiterpos, dotpos - delimiterpos, "/journey");
+        } else if (is_spatterlight_arthur) {
+            file_name.replace(delimiterpos, dotpos - delimiterpos, "/arthur");
+        }
         if (file_name != game_file) {
             find_graphics_files(file_name);
         }

--- a/terps/bocfel/z6/journey.hpp
+++ b/terps/bocfel/z6/journey.hpp
@@ -20,9 +20,6 @@ void journey_adjust_image(int picnum, uint16_t *x, uint16_t *y, int width, int h
 int journey_draw_picture(int pic, winid_t journey_window);
 
 void journey_update_on_resize(void);
-void journey_update_after_restore(void);
-void journey_update_after_autorestore(void);
-bool journey_autorestore_internal_read_char_hacks(void);
 
 void after_INTRO(void);
 void REFRESH_SCREEN(void);
@@ -138,6 +135,9 @@ extern JourneyAttributes ja;
 
 void stash_journey_state(library_state_data *dat);
 void recover_journey_state(library_state_data *dat);
+
+void journey_update_after_restore(void);
+bool journey_autorestore_internal_read_char_hacks(void);
 
 void journey_pre_save_hacks(void);
 void journey_post_save_hacks(void);

--- a/terps/bocfel/z6/v6_shared.cpp
+++ b/terps/bocfel/z6/v6_shared.cpp
@@ -1,0 +1,1292 @@
+//
+//  v6_shared.cpp
+//  bocfel6
+//
+//  Created by Administrator on 2024-06-09.
+//
+
+#include <sstream>
+
+#include "draw_image.hpp"
+#include "memory.h"
+#include "objects.h"
+#include "screen.h"
+#include "stack.h"
+#include "unicode.h"
+#include "zterp.h"
+#include "v6_specific.h"
+
+#include "arthur.hpp"
+
+//#include "shogun.hpp"
+//#include "zorkzero.hpp"
+
+#include "v6_shared.hpp"
+
+#define DEFINITIONS_WINDOW windows[2]
+
+int margin_images[100];
+int number_of_margin_images = 0;
+
+void add_margin_image_to_list(int image) {
+    for (int i = 0; i < number_of_margin_images; i++) {
+        if (margin_images[i] == image) {
+            // We have already added this image to the list
+            return;
+        }
+    }
+    fprintf(stderr, "z0_add_margin_image: Adding margin image %d to the update list\n", image);
+    margin_images[number_of_margin_images] = image;
+    number_of_margin_images++;
+}
+
+void clear_margin_image_list(void) {
+    number_of_margin_images = 0;
+}
+
+void refresh_margin_images(void) {
+    // We uncache all used margin images and create new ones
+
+    for (int i = 0; i < number_of_margin_images; i++) {
+        recreate_image(margin_images[i], false);
+    }
+}
+
+#pragma mark PRINT NUMBER
+
+void print_number(int number) {
+    std::ostringstream ss;
+    ss << number;
+    for (const auto &c : ss.str()) {
+        glk_put_char(c);
+    }
+}
+
+void print_right_justified_number(int number) {
+
+    int spaces;
+    if (number > 999 || number < -99) {
+        spaces = 0;
+    } else if (number > 99 || number < -9) {
+        spaces = 1;
+    } else if (number > 9 || number < 0) {
+        spaces = 2;
+    } else {
+        spaces = 3;
+    }
+
+    for (int i = 0; i < spaces; i++)
+        glk_put_char(' ');
+
+    print_number(number);
+}
+
+
+#pragma mark DEFINITIONS SCREEN
+
+#define DEFINITIONS_WIDTH 30 // FLEN in original source
+#define ARTHUR_LAST_OBJECT 0x137
+
+static void print_reverse_video_space(void) {
+    garglk_set_reversevideo(1);
+    glk_put_char(UNICODE_SPACE);
+    garglk_set_reversevideo(0);
+}
+
+// <CONSTANT FKEYS <PLTABLE !.L>>>
+static uint16_t fkeys = 0xce2a;
+
+// Return width of the widest user-defined command
+static int soft_commands_width(void) {
+    int widest = 0;
+    int num_commands = user_word(fkeys) / 2;
+    int fkey = fkeys + 2;
+    int16_t fdef;
+    for (int i = 0; i < num_commands; i++) {
+        int16_t temp = user_word(fkey);
+        if (temp < 0) {
+            fdef = user_word(fkey + 2);
+            if (fdef != 0) {
+                int length = count_characters_in_zstring(user_word(fdef)) + 4;
+                if (length > widest)
+                    widest = length;
+            }
+        }
+        fkey += 4;
+    }
+    return widest;
+}
+
+int define_window_width = 0;
+
+static void print_center_table(int y, uint16_t string) {
+    if (define_window_width == 0)
+        define_window_width = soft_commands_width();
+
+    int length = count_characters_in_zstring(string);
+    Window win = DEFINITIONS_WINDOW;
+    winid_t gwin = win.id;
+    glui32 width;
+    glk_window_get_size(gwin, &width, nullptr);
+
+    if (define_window_width != 0) {
+        glk_window_move_cursor(gwin, (width - define_window_width) / 2, y);
+        for (int i = 0; i < define_window_width; i++)
+            glk_put_char(UNICODE_SPACE);
+    }
+
+    glk_window_move_cursor(gwin, (width - length) / 2, y);
+    print_handler(unpack_string(string), nullptr);
+}
+
+static uint16_t scan_table(uint16_t value, uint16_t address, uint16_t length, bool bytewise) {
+    for (uint16_t i = 0; i < length; i++) {
+        if ((bytewise && user_byte(address) == value) ||
+            (!bytewise && user_word(address) == value)) {
+            return address;
+        }
+        address++;
+        if (!bytewise)
+            address++;
+    }
+    return 0;
+}
+
+// Print a single define menu line.
+// Either a function key name + an editable command
+// or a hard-coded menu item such as Save Definitions.
+static void display_soft(int function_key, int index, bool inverse) {
+
+    uint16_t fnames;
+
+    if (is_game(Game::Shogun)) {
+        fnames = 0x4b57;
+    } else {
+        fnames = 0xcd55;
+    }
+
+    int fdef, y;
+    fdef = user_word(function_key + 2);
+    y = index + 1;
+    if ((int16_t)user_word(function_key) < 0) { // hard-coded menu item
+        if (fdef != 0) {
+            DEFINITIONS_WINDOW.x = 1;
+            DEFINITIONS_WINDOW.y = y * gcellh;
+            if (inverse) {
+                garglk_set_reversevideo(1);
+            }
+            print_center_table(y, user_word(fdef));
+        }
+    } else {
+        glk_window_move_cursor(DEFINITIONS_WINDOW.id, 0, y);
+        DEFINITIONS_WINDOW.x = 1;
+        DEFINITIONS_WINDOW.y = y * gcellh + 1;
+
+        uint16_t key_name_string = scan_table(user_word(function_key), fnames, user_word(fnames - 2), false);
+        if (key_name_string != 0) {
+            if (inverse) {
+                garglk_set_reversevideo(0);
+            } else {
+                garglk_set_reversevideo(1);
+            }
+            print_handler(unpack_string(user_word(key_name_string + 2)), nullptr);
+            garglk_set_reversevideo(0);
+            glk_put_char(UNICODE_SPACE);
+            if (inverse) {
+                garglk_set_reversevideo(1);
+            }
+        }
+        int string_length = user_byte(fdef);
+        for (int i = 0; i < string_length; i++) {
+            uint8_t c = user_byte(fdef + 2 + i);
+            if (c == ZSCII_NEWLINE)
+                glk_put_char('|');
+            else
+                glk_put_char(c);
+        }
+        glsi32 x = user_byte(fdef + 1) + 4;
+
+        // Print cursor if this is the selected line
+        if (!inverse) {
+            glk_window_move_cursor(DEFINITIONS_WINDOW.id, x, y);
+            print_reverse_video_space();
+            glk_window_move_cursor(DEFINITIONS_WINDOW.id, x, y);
+        }
+    }
+    garglk_set_reversevideo(0);
+}
+
+static int global_define_line = 0;
+
+static void display_softs(void) {
+    uint16_t number_of_lines = user_word(fkeys) / 2;
+    winid_t win = DEFINITIONS_WINDOW.id;
+    glk_set_window(win);
+    glui32 width;
+    glk_window_get_size(win, &width, nullptr);
+    int16_t xpos = (width - 14) / 2;
+    if (xpos < 0)
+        xpos = 0;
+    glk_window_move_cursor(win, xpos, 0);
+    glk_put_string(const_cast<char*>("Function Keys"));
+    uint16_t function_key = fkeys + 2;
+    for (int i = 0; i < number_of_lines; i++) {
+        display_soft(function_key, i, (i != global_define_line));
+        function_key = function_key + 4;
+    }
+}
+
+void z0_erase_screen(void) {
+//    clear_image_buffer();
+//    clear_margin_image_list();
+//    if (z0_right_status_window != nullptr) {
+//        gli_delete_window(z0_right_status_window);
+//        z0_right_status_window = nullptr;
+//    }
+//    if (V6_TEXT_BUFFER_WINDOW.id != nullptr)
+//        glk_window_clear(V6_TEXT_BUFFER_WINDOW.id);
+//    if (V6_STATUS_WINDOW.id != nullptr)
+//        glk_window_clear(V6_STATUS_WINDOW.id);
+//    glk_window_clear(graphics_win_glk);
+}
+
+
+void adjust_definitions_window(void) {
+    uint8_t SCRH = byte(0x21);
+    uint8_t SCRV = byte(0x20);
+
+    uint16_t fkey = fkeys + 2 + 4 * global_define_line;
+    uint16_t fdef = user_word(fkey + 2);
+
+    int16_t left = (SCRH - user_byte(fdef)) / 2;
+    int16_t linmax = user_word(fkeys) / 2;
+
+
+    glk_stylehint_set(wintype_TextGrid, style_Normal, stylehint_TextColor, user_selected_foreground);
+    glk_stylehint_set(wintype_TextGrid, style_Normal, stylehint_BackColor, user_selected_background);
+
+    v6_delete_win(&DEFINITIONS_WINDOW);
+    DEFINITIONS_WINDOW.id = gli_new_window(wintype_TextGrid, 0);
+
+    v6_define_window( &DEFINITIONS_WINDOW, gcellw * left - ggridmarginx, gcellh * (SCRV - linmax) / 2 - ggridmarginy, (DEFINITIONS_WIDTH + 5) * gcellw + 1 + 2 * ggridmarginx, (linmax + 1) * gcellh + 2 * ggridmarginy);
+
+    glk_set_window(DEFINITIONS_WINDOW.id);
+    win_setbgnd(DEFINITIONS_WINDOW.id->peer, user_selected_background);
+    glk_request_mouse_event(DEFINITIONS_WINDOW.id);
+
+    display_softs();
+
+    // Print selected line a second time
+    // just to move the cursor into position
+    display_soft(fkey, global_define_line, false);
+}
+
+// Shared between Zork Zero and Shogun
+void V_DEFINE(void) {
+//    int linmax;
+//    uint16_t fkey, fdef, clicked_line, pressed_fkey, length;
+//
+//    if (is_game(Game::ZorkZero)) {
+//        fkeys = 0xce2a;
+//        update_user_defined_colors();
+//    } else { // Game is Shogun
+//        fkeys = 0x4dc8;
+//    }
+//
+//    win_sizewin(graphics_win_glk->peer, 0, 0, gscreenw, gscreenh);
+//    v6_define_window(&V6_TEXT_BUFFER_WINDOW, 1, 1, gscreenw, gscreenh);
+//    v6_delete_win(&V6_STATUS_WINDOW);
+//    glk_stylehint_set(wintype_TextGrid, style_Normal, stylehint_ReverseColor, 0);
+//    screenmode = MODE_DEFINE;
+//
+//    fkey = fkeys + 2;
+//    fdef = user_word(fkey + 2);
+//    linmax = user_word(fkeys) / 2;
+//
+//    global_define_line = 0;
+//
+//    adjust_definitions_window();
+//
+//    z0_erase_screen();
+//
+//    winid_t gwin = DEFINITIONS_WINDOW.id;
+//
+//    bool finished = false;
+//
+//    while (!finished)  {
+//        int16_t new_line = global_define_line;
+//        uint16_t chr = read_char();
+//        switch (chr) {
+//            case ZSCII_CLICK_SINGLE:
+//                // fallthrough
+//            case ZSCII_CLICK_DOUBLE:
+//                glk_request_mouse_event(gwin);
+//                clicked_line = line_clicked();
+//                if (clicked_line <= 1) {
+//                    break;
+//                }
+//                new_line = clicked_line - 2;
+//
+//                // Deselect the old line and select the clicked one.
+//                // This is identical to the code at the end of the input loop
+//                // but must be repeated here in order to make the double click
+//                // below apply to the right line
+//                if (global_define_line != new_line) {
+//                    display_soft(fkey, global_define_line, true);
+//                    fkey = fkeys + 2 + 4 * new_line;
+//                    display_soft(fkey, new_line, false);
+//                    global_define_line = new_line;
+//                    fdef = user_word(fkey + 2);
+//                }
+//
+//                // if we double clicked a command (as opposed to a definition)
+//                // we fall through and treat it as ZSCII_NEWLINE.
+//                // Otherwise we break.
+//                if (!(chr == ZSCII_CLICK_DOUBLE && (int16_t)user_word(fkey) < 0)) {
+//                    break;
+//                }
+//                // fallthrough
+//            case ZSCII_NEWLINE:
+//                // if we are on a static command, run the associated routine
+//                if ((int16_t)user_word(fkey) < 0) {
+//                    if (internal_call(user_word(fdef + 2))) {
+//                        // Exit menu if the call returns true
+//                        finished = true;
+//                    } else {
+//                        // Otherwise select EXIT (bottom line)
+//                        display_softs();
+//                        new_line = linmax - 1;
+//                    }
+//                    break;
+//                }
+//
+//                // If we are not on a static command, we fall through
+//                // and treat ZSCII_NEWLINE as ZSCII_DOWN.
+//
+//                // fallthrough
+//            case ZSCII_DOWN:
+//            case ZSCII_KEY2:
+//                new_line++;
+//                if (new_line < linmax) {
+//                    // Skip the blank line between definitions
+//                    // and commands
+//                    if (user_word(fkeys + 4 + 4 * new_line) == 0)
+//                        new_line++;
+//                } else {
+//                    new_line = 0;
+//                }
+//                break;
+//
+//            case ZSCII_UP:
+//            case ZSCII_KEY8:
+//                new_line--;
+//                if (new_line >= 0) {
+//                    // Skip the blank line between definitions
+//                    // and commands
+//                    if (user_word(fkeys + 4 + 4 * new_line) == 0)
+//                        new_line--;
+//                } else {
+//                    new_line = linmax - 1;
+//                }
+//                break;
+//
+//            default:
+//                // If the user pressed a function key, move to the corresponding line
+//                pressed_fkey = scan_table(chr, fkeys + 2, user_word(fkeys), false);
+//                if (pressed_fkey) {
+//                    new_line = (pressed_fkey - fkeys) / 4;
+//                    // skip text editing if we are on a static command line
+//                } else if ((int16_t)user_word(fkey) >= 0) {
+//                    if (chr == ZSCII_BACKSPACE || chr == 127) {
+//                        length = user_byte(fdef + 1);
+//                        if (length != 0) {
+//                            length--;
+//                            store_byte(fdef + 1, length);
+//                            store_byte(fdef + length + 2, ZSCII_SPACE);
+//                            // print cursor at new position
+//                            glk_window_move_cursor(gwin, length + 4, global_define_line + 1);
+//                            if (length + 1 < user_byte(fdef)) {
+//                                print_reverse_video_space();
+//                            }
+//                            glk_put_char(UNICODE_SPACE);
+//                            glk_window_move_cursor(gwin, length + 4, global_define_line + 1);
+//                        } else {
+//                            win_beep(1);
+//                        }
+//                    } else if (chr >= ZSCII_SPACE && chr < 127) {
+//                        length = user_byte(fdef + 1);
+//                        if (length + 1 >= user_byte(fdef)) {
+//                            win_beep(1);
+//                            // If the command has ZSCII_NEWLINE at the end, allow no more characters
+//                        } else if (scan_table(ZSCII_NEWLINE, fdef + 2, user_byte(fdef + 1), true) != 0) {
+//                            win_beep(1);
+//                        } else {
+//                            if (chr == '|' || chr == '!') {
+//                                chr = ZSCII_NEWLINE;
+//                            }
+//                            // store new length
+//                            store_byte(fdef + 1, length + 1);
+//
+//                            // make lowercase
+//                            if (chr >= 'A' && chr <= 'Z')
+//                                chr += 32;
+//
+//                            // add the typed character to the end of the definition string
+//                            store_byte(fdef + length + 2, chr);
+//                            // and print it
+//                            if (chr == ZSCII_NEWLINE) {
+//                                glk_put_char('|');
+//                            } else {
+//                                glk_put_char(chr);
+//                            }
+//                            // print cursor at the new position if we are not at max
+//                            if (length + 2 < user_byte(fdef)) {
+//                                print_reverse_video_space();
+//                                glk_window_move_cursor(gwin, length + 5, global_define_line + 1);
+//                            } else {
+//                                // print cursor at end of line if we are at max
+//                                glk_window_move_cursor(gwin, user_byte(fdef) + 3, global_define_line + 1);
+//                                print_reverse_video_space();
+//                            }
+//                        }
+//                    } else {
+//                        win_beep(1);
+//                    }
+//                } else {
+//                    win_beep(1);
+//                }
+//                break;
+//        }
+//
+//        // Deselect the old line
+//        // and select the new one
+//        if (global_define_line != new_line) {
+//            display_soft(fkey, global_define_line, true);
+//            display_soft(fkeys + 2 + 4 * new_line, new_line, false);
+//            global_define_line = new_line;
+//            fkey = fkeys + 2 + 4 * global_define_line;
+//            fdef = user_word(fkey + 2);
+//        }
+//    };
+//
+//    v6_delete_win(&DEFINITIONS_WINDOW);
+//    screenmode = MODE_NORMAL;
+//    if (is_game(Game::ZorkZero)) {
+//        z0_update_on_resize();
+//    } else {
+//        // Game is Shogun
+//        internal_call(pack_routine(0x183a4)); // V-REFRESH
+//    }
+}
+
+#pragma mark HINTS SCREEN
+
+// Shared between Zork Zero, Shogun, and Arthur
+
+// To keep track of the main buffer window while
+// using a grid for the hints menu
+winid_t stored_bufferwin = nullptr;
+
+uint8_t hint_chapter_global_idx = 0;
+uint8_t hint_quest_global_idx = 0;
+
+uint16_t hints_table_addr = 0;
+
+glui32 upperwin_foreground = zcolor_Default; // black
+glui32 upperwin_background = zcolor_Default; // white
+
+InfocomV6MenuType hints_depth = kV6MenuTypeTopic;
+
+uint16_t h_chapt_num = 1;
+uint16_t h_quest_num = 1;
+
+// HINT-COUNTS in original source
+// 0xe9d2 is value for Zork Zero release 393
+uint16_t seen_hints_table_addr = 0xe9d2;
+
+int print_long_zstr_to_cstr(uint16_t addr, char *str, int maxlen);
+
+static int16_t select_hint_by_mouse(int16_t *chr) {
+    glk_cancel_char_event(V6_STATUS_WINDOW.id);
+    set_current_window(&V6_TEXT_BUFFER_WINDOW);
+    glk_request_mouse_event(V6_STATUS_WINDOW.id);
+    glk_request_mouse_event(V6_TEXT_BUFFER_WINDOW.id);
+
+    *chr = internal_read_char();
+
+    if (*chr != ZSCII_CLICK_SINGLE && *chr != ZSCII_CLICK_DOUBLE)
+        return 0;
+
+    uint16_t mouse_click_addr = header.extension_table + 2;
+    int16_t x = word(mouse_click_addr) - 1;
+    int16_t y = word(mouse_click_addr + 2) - 1;
+
+    glui32 upperwidth, lowerwidth, lowerheight;
+    glk_window_get_size(V6_STATUS_WINDOW.id, &upperwidth, nullptr);
+
+    int left = (upperwidth - 15) / 2;
+    if (left < 0)
+        left = upperwidth / 3;
+    int right = upperwidth - left;
+    if (y == 1) {
+        if (x <= left) {
+            *chr = 'N';
+        } else if (x > right) {
+            *chr = ZSCII_NEWLINE;
+        } else {
+            *chr = 'M';
+        }
+    } else if (y == 2) {
+        if (x <= left) {
+            *chr = 'P';
+        } else if (x > right) {
+            *chr = 'Q';
+        }
+    }
+
+    y -= 2;
+
+    if (y <= 0) {
+        return 0;
+    }
+
+    glk_window_get_size(V6_TEXT_BUFFER_WINDOW.id, &lowerwidth, &lowerheight);
+
+    if (x >= lowerwidth / 2) { // in right column
+        y += lowerheight;
+    }
+
+    return y;
+}
+
+
+//  Arthur has contextual hints that
+//  might not be shown, so the internal index of
+//  a hint might not match its line on-screen.
+//  If the game is not Arthur, these two functions
+//  return the argument unchanged
+
+static uint16_t index_to_line(uint16_t index) {
+    if (is_game(Game::Arthur)) {
+        uint16_t max = user_word(at.K_HINT_ITEMS);
+        for (int i = 1; i <= max; i++) {
+            if (user_word(at.K_HINT_ITEMS + i * 2) == index)
+                return i;
+        }
+        return user_word(at.K_HINT_ITEMS + 2);
+    }
+    return index;
+}
+
+static uint16_t line_to_index(uint16_t line) {
+    if (is_game(Game::Arthur)) {
+        uint16_t max = user_word(at.K_HINT_ITEMS);
+        if (line > 1 && line <= max)
+            return (user_word(at.K_HINT_ITEMS + line * 2));
+        return 1;
+    }
+    return line;
+}
+
+static void draw_hints_windows(void) {
+
+    upperwin_foreground = user_selected_foreground;
+    upperwin_background = user_selected_background;
+
+    if (!is_spatterlight_arthur) {
+        if (graphics_type == kGraphicsTypeBlorb || graphics_type == kGraphicsTypeVGA || graphics_type == kGraphicsTypeAmiga) {
+            upperwin_background = 0x826766;
+        } else if (graphics_type == kGraphicsTypeEGA) {
+            upperwin_background = 0xd47fd4;
+        } else if ((graphics_type == kGraphicsTypeMacBW || graphics_type == kGraphicsTypeCGA) && is_game(Game::Arthur)) {
+            upperwin_background = monochrome_black;
+            upperwin_foreground = monochrome_white;
+        } else if (graphics_type == kGraphicsTypeMacBW) {
+            upperwin_background = monochrome_black;
+            upperwin_foreground = monochrome_white;
+        }
+        if (graphics_type == kGraphicsTypeVGA || graphics_type == kGraphicsTypeEGA || graphics_type == kGraphicsTypeApple2) {
+            upperwin_foreground = 0xffffff;
+            if (upperwin_background == 0xffffff)
+                upperwin_foreground = user_selected_background;
+            if (upperwin_foreground == 0xffffff)
+                upperwin_foreground = 0;
+        }
+    }
+
+    glk_stylehint_set(wintype_TextGrid, style_Normal, stylehint_TextColor, upperwin_foreground);
+    glk_stylehint_set(wintype_TextGrid, style_Normal, stylehint_BackColor, upperwin_background);
+
+    win_refresh(V6_TEXT_BUFFER_WINDOW.id->peer, 0, 0);
+    glk_window_clear(V6_TEXT_BUFFER_WINDOW.id);
+
+    if (hints_depth != kV6MenuTypeHint && V6_TEXT_BUFFER_WINDOW.id->type == wintype_TextBuffer) {
+        v6_remap_win(&V6_TEXT_BUFFER_WINDOW, wintype_TextGrid, &stored_bufferwin);
+    } else if (V6_TEXT_BUFFER_WINDOW.id->type == wintype_TextGrid) {
+        v6_delete_win(&V6_TEXT_BUFFER_WINDOW);
+        V6_TEXT_BUFFER_WINDOW.id = stored_bufferwin;
+        v6_sizewin(&V6_TEXT_BUFFER_WINDOW);
+    }
+
+    int width = 1;
+    int status_x = 0;
+    int height = V6_STATUS_WINDOW.y_size + gcellh;
+
+    if (is_game(Game::ZorkZero)) {
+//        // Global BORDER-ON, false if in text-only mode
+//        bool text_only_mode = (get_global(0x83) == 0);
+//        if (!text_only_mode) {
+//            DISPLAY_BORDER(HINT_BORDER);
+//            get_image_size(TEXT_WINDOW_PIC_LOC, &width, &height);
+//            width = width * imagescalex;
+//            height = height * imagescaley;
+//        }
+    } else if (is_game(Game::Shogun)) {
+//        shogun_display_border(P_HINT_BORDER);
+//        if (graphics_type == kGraphicsTypeApple2) {
+//            width = 0;
+//            int a2_graphical_banner_height;
+//            get_image_size(P_BORDER, nullptr, &a2_graphical_banner_height);
+//            height += a2_graphical_banner_height;
+//        } else {
+//            get_image_size(P_HINT_LOC, &width, &height);
+//            if (graphics_type == kGraphicsTypeCGA) {
+//                width += 3;
+//            }
+//            width *= imagescalex;
+//            height *= imagescaley;
+//            if (graphics_type != kGraphicsTypeAmiga && graphics_type != kGraphicsTypeMacBW) {
+//                status_x = width;
+//            }
+//        }
+    }
+
+    v6_define_window(&V6_STATUS_WINDOW, status_x, 1, gscreenw - 2 * status_x, gcellh * 3 + 2 * ggridmarginy);
+
+    V6_STATUS_WINDOW.x = 0;
+    V6_STATUS_WINDOW.y = 0;
+
+    if (is_spatterlight_arthur) {
+        height = V6_STATUS_WINDOW.y_size + gcellh;
+    }
+
+    if (height < V6_STATUS_WINDOW.y_size + 1) {
+        height = V6_STATUS_WINDOW.y_size + 1;
+    }
+
+    v6_define_window(&V6_TEXT_BUFFER_WINDOW, width, height, gscreenw - 2 * width, gscreenh - height);
+
+    flush_bitmap(current_graphics_buf_win);
+
+    win_refresh(V6_STATUS_WINDOW.id->peer, 0, 0);
+    win_refresh(V6_TEXT_BUFFER_WINDOW.id->peer, 0, 0);
+
+    glk_window_clear(V6_STATUS_WINDOW.id);
+    glk_window_clear(V6_TEXT_BUFFER_WINDOW.id);
+
+    set_current_window(&V6_TEXT_BUFFER_WINDOW);
+    glk_request_char_event(V6_TEXT_BUFFER_WINDOW.id);
+}
+
+static void center_line(const char *str, int line, int length, bool reverse) {
+    glui32 width;
+    winid_t win = V6_STATUS_WINDOW.id;
+    glk_window_get_size(win, &width, nullptr);
+    if (length > width)
+        width = length;
+    glk_window_move_cursor(win, (width - length) / 2, line - 1);
+    if (reverse)
+        garglk_set_reversevideo(1);
+    glk_put_string(const_cast<char *>(str));
+    garglk_set_reversevideo(0);
+}
+
+static void right_line(const char *str, int line, int length) {
+    glui32 width;
+    winid_t win = V6_STATUS_WINDOW.id;
+    glk_window_get_size(win, &width, nullptr);
+    if (length > width)
+        width = length;
+    glk_set_window(win);
+    glk_window_move_cursor(win, width - length, line - 1);
+    glk_put_string(const_cast<char *>(str));
+}
+
+static void left_line(const char *str, int line) {
+    winid_t win = V6_STATUS_WINDOW.id;
+    glk_window_move_cursor(win, 0, line - 1);
+    glk_put_string(const_cast<char *>(str));
+}
+
+static void hint_title(const char *title, int length) {
+    if (hints_depth != kV6MenuTypeHint)
+        win_menuitem(kV6MenuExited, 0, 0, 0, nullptr, 0);
+    winid_t win = V6_STATUS_WINDOW.id;
+    glk_set_window(win);
+    glk_window_clear(win);
+    center_line(title, 1, length, true);
+
+    if (hints_depth != kV6MenuTypeHint) {
+        left_line("N for next item.", 2);
+        left_line("P for previous item.", 3);
+    }
+
+    if (hints_depth != kV6MenuTypeTopic) {
+        center_line("M for hint menu.", 2, 16, false);
+    }
+    if (mouse_available()) {
+        center_line("(Or use mouse.)", 3, 16, false);
+    }
+
+    if (hints_depth == kV6MenuTypeHint)
+        right_line("Return for a hint.", 2, 18);
+    else
+        right_line("Return for hints.", 2, 17);
+
+    right_line("Q to resume story.", 3, 18);
+
+    win_menuitem(kV6MenuTitle, 0, hints_depth, 0, const_cast<char *>(title), length);
+}
+
+static bool rt_see_qst(int16_t obj) {
+    return (internal_call_with_arg(pack_routine(ar.RT_SEE_QST), obj) == 1);
+}
+
+static uint16_t hint_question_name(uint16_t question) {
+    uint16_t result = user_word(hints_table_addr + h_chapt_num * 2);
+    uint16_t base_address = user_word(result + (question + 1) * 2);
+
+    if (is_game(Game::Arthur)) {
+        base_address += 2;
+        if (!rt_see_qst(user_word(base_address)))
+            return 0;
+    }
+
+    return user_word(base_address + 2);
+}
+
+static bool arthur_is_topic_in_context(uint16_t topic) {
+    int16_t max = user_word(topic);
+    for (uint16_t i = 2; i <= max; i++) {
+        if (rt_see_qst(user_word(user_word(topic + i * 2) + 2)))
+            return true;
+    }
+    return false;
+}
+
+static uint16_t hint_topic_name(uint16_t chapter) {
+    uint16_t topic = user_word(hints_table_addr + chapter * 2);
+
+    if (is_game(Game::Arthur) && !arthur_is_topic_in_context(topic))
+        return 0;
+
+    return user_word(topic + 2);
+}
+
+static int16_t get_seen_hints(void) {
+
+    // seen_hints_table_addr points to a byte table that keeps track of
+    // how many hints have been shown for a particular question.
+    // Actually a nibble table. The high four bits of each byte store
+    // odd question numbers; the low four bits store even question numbers.
+
+    int16_t cv = user_word(seen_hints_table_addr + (h_chapt_num - 1) * 2);
+    int16_t address = cv + (h_quest_num - 1) / 2;
+    int16_t seen = user_byte(address);
+    bool odd = ((h_quest_num & 1) == 1);
+    if (odd) {
+        seen = seen >> 4;
+    }
+    return seen & 0xf;
+}
+
+
+static void send_menuitem(uint16_t str, int max) {
+    char string[4000];
+    int length = print_long_zstr_to_cstr(str, string, 4000);
+    glk_put_string(string);
+    int index;
+    switch (hints_depth) {
+        case kV6MenuTypeQuestion:
+            index = h_quest_num - 1;
+            break;
+        case kV6MenuTypeTopic:
+            index = h_chapt_num - 1;
+            break;
+        case kV6MenuTypeHint:
+            index = get_seen_hints() - 1;
+            break;
+        default:
+            fprintf(stderr, "send_menuitem: Illegal menu type!\n");
+            return;
+    }
+    if (index >= max)
+        index = max - 1;
+    win_menuitem(hints_depth, index, max, 0, string, length);
+}
+
+
+
+static int hint_put_up_frobs(uint16_t max, uint16_t start) {
+    uint16_t x = 0;
+    uint16_t y = 0;
+    glui32 width, height;
+
+    if (V6_TEXT_BUFFER_WINDOW.id->type == wintype_TextBuffer) {
+        glk_cancel_char_event(V6_TEXT_BUFFER_WINDOW.id);
+        v6_remap_win(&V6_TEXT_BUFFER_WINDOW, wintype_TextGrid, &stored_bufferwin);
+        glk_request_char_event(V6_TEXT_BUFFER_WINDOW.id);
+
+    }
+    glk_window_get_size(V6_TEXT_BUFFER_WINDOW.id, &width, &height);
+    set_current_window(&V6_TEXT_BUFFER_WINDOW);
+
+    uint16_t str;
+    int number_of_entries = 0;
+    for (int i = start; i <= max; i++) {
+        if (hints_depth == kV6MenuTypeTopic) {
+            str = hint_topic_name(i);
+        } else {
+            str = hint_question_name(i);
+        }
+        if (str == 0)
+            continue;
+        number_of_entries++;
+        if (is_game(Game::Arthur)) {
+            store_word(at.K_HINT_ITEMS + number_of_entries * 2, i);
+        }
+        glk_window_move_cursor(V6_TEXT_BUFFER_WINDOW.id, x, y);
+        send_menuitem(str, number_of_entries);
+
+        y++;
+        V6_TEXT_BUFFER_WINDOW.x = 1;
+        if (y == height) {
+            y = 0;
+            x = width / 2;
+        }
+    }
+    if (is_game(Game::Arthur)) {
+        store_word(at.K_HINT_ITEMS, number_of_entries); // the first word of a table contains the length
+    }
+    return number_of_entries;
+}
+
+static int hint_new_cursor(uint16_t pos, bool reverse) {
+    uint16_t x = 0;
+    if ((int16_t)pos < 1)
+        pos = 1;
+    uint16_t y = pos - 1;
+    glui32 width, height;
+    glk_window_get_size(V6_TEXT_BUFFER_WINDOW.id, &width, &height);
+    if (pos > height) {
+        x = width / 2;
+        y -= height;
+    }
+    glk_window_move_cursor(V6_TEXT_BUFFER_WINDOW.id, x, y);
+    V6_TEXT_BUFFER_WINDOW.x = 1;
+    if (reverse)
+        garglk_set_reversevideo(1);
+
+    uint16_t index = line_to_index(pos);
+    uint16_t string_address;
+    if (hints_depth == kV6MenuTypeTopic) {
+        string_address = hint_topic_name(index);
+    } else {
+        string_address = hint_question_name(index);
+    }
+    print_handler(unpack_string(string_address), nullptr);
+    garglk_set_reversevideo(0);
+    return x;
+}
+
+// Store the index of the last shown
+// hint in the nibble table
+static void store_hints_seen(uint8_t value) {
+    int16_t cv = user_word(seen_hints_table_addr + (h_chapt_num - 1) * 2);
+    int16_t address = cv + (h_quest_num - 1) / 2;
+    uint8_t seen = user_byte(address);
+    bool odd = ((h_quest_num & 1) == 1);
+    if (odd) {
+        seen = seen & 0x0f;
+        value = value << 4;
+    } else {
+        seen = seen & 0xf0;
+        value = value & 0x0f;
+    }
+    value = seen | value;
+    store_byte(address, value);
+}
+
+static int16_t init_hints(int16_t *hints_base_address) {
+
+    int16_t h = user_word(user_word(hints_table_addr + h_chapt_num * 2) + (h_quest_num + 1) * 2);
+    char str[64];
+
+    int offset = is_spatterlight_arthur ? 4 : 2;
+
+    int length = print_long_zstr_to_cstr(user_word(h + offset), str, 64);
+    hint_title(str, length);
+
+    int16_t seen = get_seen_hints();
+    int16_t max = user_word(h) - 1;
+
+    if (seen == max) {
+        // Remove the text "Return for a hint" if there are no more hints.
+        right_line("                  ", 2, 18);
+    }
+    glk_set_window(V6_TEXT_BUFFER_WINDOW.id);
+
+    if (hints_base_address != nullptr)
+        *hints_base_address = h;
+    return max;
+}
+
+static bool display_hints(bool only_refresh) {
+    hints_depth = kV6MenuTypeHint;
+
+    win_menuitem(kV6MenuExited, 0, 0, 0, nullptr, 0);
+
+    int16_t hints_base_address;
+
+    if (V6_TEXT_BUFFER_WINDOW.id && V6_TEXT_BUFFER_WINDOW.id->type == wintype_TextGrid) {
+        v6_delete_win(&V6_TEXT_BUFFER_WINDOW);
+        V6_TEXT_BUFFER_WINDOW.id = gli_new_window(wintype_TextBuffer, 0);
+        v6_sizewin(&V6_TEXT_BUFFER_WINDOW);
+    }
+    int16_t max = init_hints(&hints_base_address);
+    set_current_window(&V6_TEXT_BUFFER_WINDOW);
+    glk_window_clear(V6_TEXT_BUFFER_WINDOW.id);
+
+    int16_t seen = get_seen_hints();
+
+    if (seen <= 1) {
+        win_menuitem(kV6MenuTypeHint, 0, max - 1, 0, 0, 0);
+    }
+
+    bool done = false;
+    bool result = false;
+
+    int16_t cnt;
+
+    for (cnt = is_game(Game::Arthur) ? 1 : 0; cnt <= max; cnt++) {
+        store_hints_seen(cnt);
+        if (cnt == max) {
+            char *str = const_cast<char *>("[No more hints.]\n");
+            glk_put_string(str);
+            win_menuitem(kV6MenuTypeHint, max, max - 1, 0, str, 17);
+
+            // Remove "Return for a hint."
+            right_line("                  ", 2, 18);
+        } else {
+            print_number(max - cnt);
+            glk_put_char('>');
+            glk_put_char(UNICODE_SPACE);
+        }
+        set_current_window(&V6_TEXT_BUFFER_WINDOW);
+        if (cnt >= seen) {
+            if (only_refresh) {
+                return false;
+            }
+            bool loop = true;
+            while (loop) {
+                int16_t chr;
+                select_hint_by_mouse(&chr);
+                switch (chr) {
+                    case ZSCII_NEWLINE:
+                    case UNICODE_LINEFEED:
+                        if (cnt < max) {
+                            loop = false;
+                        } else {
+                            win_beep(1);
+                        }
+                        break;
+                    case 'm':
+                    case 'M':
+                        result = true;
+                    case 'q':
+                    case 'Q':
+                        done = true;
+                        loop = false;
+                        break;
+                    default:
+                        win_beep(1);
+                        break;
+                }
+            }
+
+            if (done)
+                break;
+        }
+
+        if (cnt < max) {
+            int16_t str = user_word(hints_base_address + (cnt + 2) * 2);
+            send_menuitem(str, max - 1);
+            glk_put_char(UNICODE_LINEFEED);
+        }
+    }
+
+    if (V6_TEXT_BUFFER_WINDOW.id->type == wintype_TextBuffer) {
+        stored_bufferwin = V6_TEXT_BUFFER_WINDOW.id;
+        win_sizewin(stored_bufferwin->peer, 0, 0, 0, 0);
+        V6_TEXT_BUFFER_WINDOW.id = nullptr;
+    }
+    v6_remap_win_to_grid(&V6_TEXT_BUFFER_WINDOW);
+    glk_request_char_event(V6_TEXT_BUFFER_WINDOW.id);
+
+    hints_depth = kV6MenuTypeQuestion;
+
+    return result;
+}
+
+static bool hint_inner_menu_loop(uint16_t *index, uint16_t num_entries, InfocomV6MenuType name_routine, bool *exit_hint_menu);
+
+static int display_questions(void) {
+    char str[30];
+    int length = print_long_zstr_to_cstr(user_word(user_word(hints_table_addr + h_chapt_num * 2) + 2), str, 30);
+    hint_title(str, length);
+    uint16_t max = user_word(user_word(hints_table_addr + h_chapt_num * 2)) - 1;
+    int number_of_entries = hint_put_up_frobs(max, 1);
+    hint_new_cursor(index_to_line(h_quest_num), true);
+    return number_of_entries;
+}
+
+static bool hint_pick_question(void) {
+    bool result = true;
+
+    bool outer_loop = true;
+
+    while (outer_loop) {
+        hints_depth = kV6MenuTypeQuestion;
+
+        glk_window_clear(V6_TEXT_BUFFER_WINDOW.id);
+        uint16_t max = display_questions();
+        outer_loop = hint_inner_menu_loop(&h_quest_num, max, kV6MenuTypeQuestion, &result);
+    }
+    hints_depth = kV6MenuTypeTopic;
+    return result;
+}
+
+static bool hint_inner_menu_loop(uint16_t *index, uint16_t num_entries, InfocomV6MenuType local_menu_depth, bool *exit_hint_menu) {
+    bool loop = true;
+    bool outer_loop = true;
+    bool done = true;
+    uint16_t selected_line = index_to_line(*index);
+    glui32 column_height;
+
+    while (loop) {
+        uint16_t new_selection = selected_line;
+        *index = line_to_index(selected_line);
+        int16_t chr;
+        int16_t mouse = select_hint_by_mouse(&chr);
+        glk_window_get_size(V6_TEXT_BUFFER_WINDOW.id, nullptr, &column_height);
+        switch (chr) {
+            case 'Q':
+            case 'q':
+                done = false;
+                outer_loop = false;
+                loop = false;
+                break;
+            case 'm':
+            case 'M':
+                if (local_menu_depth == kV6MenuTypeQuestion) {
+                    loop = false;
+                    outer_loop = false;
+                } else {
+                    win_beep(1);
+                }
+                break;
+            case ZSCII_LEFT:
+                if (selected_line > column_height)
+                    selected_line -= column_height;
+                else
+                    win_beep(1);
+                break;
+            case ZSCII_RIGHT:
+                if (num_entries >= selected_line + column_height)
+                    selected_line += column_height;
+                else
+                    win_beep(1);
+                break;
+            case 'n':
+            case 'N':
+            case ZSCII_DOWN:
+                if (num_entries == 1) {
+                    win_beep(1);
+                } else if (selected_line == num_entries)
+                    selected_line = 1;
+                else
+                    selected_line++;
+                break;
+            case 'p':
+            case 'P':
+            case ZSCII_UP:
+                if (num_entries == 1) {
+                    win_beep(1);
+                } else if (selected_line == 1)
+                    selected_line = num_entries;
+                else
+                    selected_line--;
+                break;
+            case ZSCII_CLICK_SINGLE:
+            case ZSCII_CLICK_DOUBLE:
+                if (mouse >= 1 && mouse <= num_entries) {
+                    selected_line = mouse;
+                    if (chr == ZSCII_CLICK_SINGLE) {
+                        break;
+                    }
+                } else {
+                    win_beep(1);
+                    break;
+                }
+            case ZSCII_NEWLINE:
+            case UNICODE_LINEFEED:
+            case ZSCII_SPACE:
+                if (local_menu_depth == kV6MenuTypeTopic) {
+                    outer_loop = hint_pick_question();
+                } else {
+                    outer_loop = display_hints(false);
+                    done = outer_loop;
+                }
+                loop = false;
+                break;
+            default:
+                win_beep(1);
+        }
+        if (selected_line != new_selection) {
+            hint_new_cursor(new_selection, false);
+            hint_new_cursor(selected_line, true);
+
+            win_menuitem(kV6MenuSelectionChanged, selected_line - 1, 0, 0, nullptr, 0);
+
+            if (local_menu_depth == kV6MenuTypeTopic) {
+                h_quest_num = 1;
+                set_global(hint_quest_global_idx, 1);
+                set_global(hint_chapter_global_idx, line_to_index(selected_line));
+            } else {
+                set_global(hint_quest_global_idx, line_to_index(selected_line));
+            }
+        }
+    }
+    if (exit_hint_menu != nullptr) {
+        *exit_hint_menu = done;
+    }
+
+    return outer_loop;
+}
+
+static int display_topics(void) {
+    hint_title(const_cast<char *>(" InvisiClues (tm) "), 18);
+    int number_of_entries = hint_put_up_frobs(user_word(hints_table_addr), 1);
+    hint_new_cursor(index_to_line(h_chapt_num), true);
+    return number_of_entries;
+}
+
+void redraw_hint_screen_on_resize(void) {
+    draw_hints_windows();
+    glk_request_char_event(V6_TEXT_BUFFER_WINDOW.id);
+    switch (hints_depth) {
+        case kV6MenuTypeHint:
+            display_hints(true);
+            break;
+        case kV6MenuTypeQuestion:
+            display_questions();
+            break;
+        default:
+            display_topics();
+            break;
+    }
+}
+
+void DO_HINTS(void) {
+    // Screenmode will be MODE_HINTS on autorestore,
+    // and we need to store the mode we were in before
+    // entering hint screen.
+    if (is_spatterlight_arthur)
+        arthur_sync_screenmode();
+
+    V6ScreenMode stored_mode = screenmode;
+
+    if (is_game(Game::Shogun) || is_spatterlight_arthur) {
+        if (is_spatterlight_arthur) {
+            clear_image_buffer();
+            if (current_graphics_buf_win)
+                glk_window_clear(current_graphics_buf_win);
+
+            // Delete the topmost window used by Arthur in its status,
+            // inventory, and room description modes.
+            v6_delete_win(&windows[2]);
+        } else {
+            // Set for Shogun (delete if set in entrypoints)
+            hints_table_addr = 0xbe99;
+        }
+        h_chapt_num = get_global(hint_chapter_global_idx);
+        h_quest_num = get_global(hint_quest_global_idx);
+    }
+
+    screenmode = MODE_HINTS;
+    draw_hints_windows();
+
+    int number_of_entries;
+    bool outer_loop = true;
+
+    while (outer_loop) {
+        glk_window_clear(V6_TEXT_BUFFER_WINDOW.id);
+
+        // Unless we are autorestoring (and this is the first iteration of the loop),
+        // hints_depth will be kV6MenuTypeTopic
+        switch (hints_depth) {
+            case kV6MenuTypeQuestion:
+                display_questions();
+                outer_loop = hint_pick_question();
+                break;
+            case kV6MenuTypeHint:
+                outer_loop = display_hints(false);
+                break;
+            case kV6MenuTypeTopic:
+                number_of_entries = display_topics();
+                outer_loop = hint_inner_menu_loop(&h_chapt_num, number_of_entries, kV6MenuTypeTopic, nullptr);
+                break;
+            default:
+                fprintf(stderr, "DO_HINTS: Illegal hints_depth value!\n");
+                return;
+        }
+    }
+
+    glk_stylehint_clear(wintype_TextGrid, style_Normal, stylehint_TextColor);
+    glk_stylehint_clear(wintype_TextGrid, style_Normal, stylehint_BackColor);
+
+    v6_sizewin(&V6_STATUS_WINDOW);
+
+    if (V6_TEXT_BUFFER_WINDOW.id->type != wintype_TextBuffer) {
+        v6_delete_win(&V6_TEXT_BUFFER_WINDOW);
+        V6_TEXT_BUFFER_WINDOW.id = stored_bufferwin;
+    }
+
+    v6_sizewin(&V6_TEXT_BUFFER_WINDOW);
+    glk_window_clear(V6_TEXT_BUFFER_WINDOW.id);
+
+    screenmode = stored_mode;
+
+    stored_bufferwin = nullptr;
+
+    hints_depth = kV6MenuTypeTopic;
+
+    win_menuitem(kV6MenuExited, 0, 0, 0, nullptr, 0);
+
+    //    if (is_game(Game::ZorkZero)) {
+    //        z0_update_on_resize();
+    //    } else if (is_game(Game::Shogun)) {
+    //        internal_call(pack_routine(0x183a4)); // V-REFRESH
+    //    }
+
+    glk_put_string(const_cast<char*>("Back to the story...\n"));
+    glk_set_echo_line_event(V6_TEXT_BUFFER_WINDOW.id, 0);
+
+    win_refresh(V6_STATUS_WINDOW.id->peer, 0, 0);
+}
+
+#pragma mark Empty functions used by entrypoints code
+
+void DISPLAY_HINT(void) {}
+void RT_SEE_QST(void) {}
+void V_COLOR(void) {}

--- a/terps/bocfel/z6/v6_shared.hpp
+++ b/terps/bocfel/z6/v6_shared.hpp
@@ -1,0 +1,49 @@
+//
+//  v6_shared.hpp
+//  bocfel6
+//
+//  Created by Administrator on 2024-06-09.
+//
+
+#ifndef v6_shared_hpp
+#define v6_shared_hpp
+
+extern "C" {
+#include "glk.h"
+#include "glkimp.h"
+}
+
+#include <stdio.h>
+
+void adjust_definitions_window(void);
+void redraw_hint_screen_on_resize(void);
+void print_number(int number);
+void print_right_justified_number(int number);
+
+extern int number_of_margin_images;
+
+void add_margin_image_to_list(int image);
+void clear_margin_image_list(void);
+void refresh_margin_images(void);
+
+void DO_HINTS(void);
+void DISPLAY_HINT(void);
+void RT_SEE_QST(void);
+
+void V_COLOR(void);
+
+extern uint8_t fg_global_idx, bg_global_idx;
+extern uint8_t hint_chapter_global_idx, hint_quest_global_idx;
+extern uint16_t hints_table_addr;
+extern uint16_t seen_hints_table_addr;
+extern winid_t stored_bufferwin;
+
+extern uint16_t h_chapt_num;
+extern uint16_t h_quest_num;
+
+extern InfocomV6MenuType hints_depth;
+
+#define V6_TEXT_BUFFER_WINDOW windows[0]
+#define V6_STATUS_WINDOW windows[1]
+
+#endif /* v6_shared_hpp */

--- a/terps/bocfel/zoom.cpp
+++ b/terps/bocfel/zoom.cpp
@@ -1,18 +1,6 @@
 // Copyright 2010-2021 Chris Spiegel.
 //
-// This file is part of Bocfel.
-//
-// Bocfel is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License, version
-// 2 or 3, as published by the Free Software Foundation.
-//
-// Bocfel is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with Bocfel. If not, see <http://www.gnu.org/licenses/>.
+// SPDX-License-Identifier: MIT
 
 #include <ctime>
 #include <string>

--- a/terps/bocfel/zterp.cpp
+++ b/terps/bocfel/zterp.cpp
@@ -1,18 +1,6 @@
 // Copyright 2009-2021 Chris Spiegel.
 //
-// This file is part of Bocfel.
-//
-// Bocfel is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License, version
-// 2 or 3, as published by the Free Software Foundation.
-//
-// Bocfel is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with Bocfel. If not, see <http://www.gnu.org/licenses/>.
+// SPDX-License-Identifier: MIT
 
 #include <algorithm>
 #include <array>
@@ -168,11 +156,14 @@ static void initialize_games()
 
     static const std::vector<std::pair<Game, std::set<std::string>>> gamemap = {
         { Game::Infocom1234, infocom1234 },
+#ifndef SPATTERLIGHT
+
         { Game::Arthur, { "74-890714" } },
-#ifdef SPATTERLIGHT
-        { Game::Journey, { "142-890205", "2-890303", "11-890304", "3-890310", "5-890310", "10-890313", "26-890316", "30-890322", "51-890522", "54-890526", "76-890615", "77-890616", "79-890627", "83-890706" } },
-#else
         { Game::Journey, { "83-890706" } },
+#else
+        { Game::Arthur, { "40-890502", "41-890504", "54-890606", "63-890622", "74-890714" } },
+
+        { Game::Journey, { "142-890205", "2-890303", "11-890304", "3-890310", "5-890310", "10-890313", "26-890316", "30-890322", "51-890522", "54-890526", "76-890615", "77-890616", "79-890627", "83-890706" } },
 #endif
         { Game::LurkingHorror, { "203-870506", "219-870912", "221-870918" } },
         { Game::Planetfall, { "1-830517", "20-830708", "26-831014", "29-840118", "37-851003", "39-880501" } },
@@ -379,7 +370,7 @@ void write_header()
 
 #ifdef SPATTERLIGHT
         options.int_number = gli_zmachine_terp;
-        if (is_spatterlight_journey) {
+        if (is_spatterlight_journey || is_spatterlight_arthur) {
             v6_switch_to_allowed_interpreter_number();
         }
 #endif
@@ -696,8 +687,11 @@ static void process_story(IO &io, long offset)
 #ifdef SPATTERLIGHT
     if (is_game(Game::Journey)) {
         is_spatterlight_journey = true;
-        find_entrypoints();
+    } else if (is_game(Game::Arthur)) {
+        is_spatterlight_arthur = true;
     }
+    if (is_spatterlight_journey || is_spatterlight_arthur)
+        find_entrypoints();
 #endif
     if (zversion <= 3) {
         have_statuswin = create_statuswin();
@@ -1039,7 +1033,7 @@ static void real_main(int argc, char **argv)
     process_story(*story.io, story.offset);
 
 #ifdef SPATTERLIGHT
-    if (is_spatterlight_journey) {
+    if (is_spatterlight_journey || is_spatterlight_arthur) {
         find_and_load_z6_graphics();
     }
 #endif
@@ -1057,7 +1051,7 @@ static void real_main(int argc, char **argv)
         user_store_word(0x10, word(0x10));
 
 #ifdef SPATTERLIGHT
-        if (!is_spatterlight_journey) {
+        if (!is_spatterlight_journey && !is_spatterlight_arthur) {
 #endif
         if (zversion == 6 && options.warn_on_v6) {
             show_message("Version 6 of the Z-machine is only partially supported. Be aware that the game might not function properly.");

--- a/terps/bocfel/zterp.h
+++ b/terps/bocfel/zterp.h
@@ -24,7 +24,7 @@ private:
 
 extern std::string game_file;
 
-#define ZTERP_VERSION	"2.2.2"
+#define ZTERP_VERSION	"2.2.3"
 
 // v3
 constexpr uint8_t FLAGS1_STATUSTYPE  = 1U << 1;

--- a/terps/plus/apple2detect.c
+++ b/terps/plus/apple2detect.c
@@ -396,7 +396,7 @@ void LookForApple2Images(void)
         Images[created].DiskOffset = list[ct].offset;
         created++;
         if (created > count) {
-            fprintf(stderr, "Error!\n");
+            fprintf(stderr, "LookForApple2Images: Error!\n");
             created--;
             break;
         }

--- a/terps/readwoz/ciderpress.c
+++ b/terps/readwoz/ciderpress.c
@@ -1737,7 +1737,6 @@ static DIError ProDOSOpen(A2File *pOpenFile)
     pOpenFile->fOffset = 0;
 
 bail:
-//    delete pOpenFile;
     return dierr;
 }
 
@@ -2350,7 +2349,7 @@ bail:
  *
  * NOTE: supposedly DOS stops reading the catalog track when it finds the
  * first entry with a 00 byte, which is why deleted files use ff.  If so,
- * it *might* make sense to mimic this behavior, though on a health disk
+ * it *might* make sense to mimic this behavior, though on a healthy disk
  * we shouldn't be finding garbage anyway.
  *
  * Fills out "fCatalogSectors" as it works.

--- a/terps/scott/ai_uk/c64decrunch.c
+++ b/terps/scott/ai_uk/c64decrunch.c
@@ -415,7 +415,7 @@ static GameIDType mysterious_menu2(uint8_t **sf, size_t *extent, int recindex)
             filename = "WAXWORKS";
             break;
         default:
-            fprintf(stderr, "Error!\n");
+            fprintf(stderr, "mysterious_menu2: Unhandled case!\n");
             break;
     }
 

--- a/terps/scott/ai_uk/game_specific.c
+++ b/terps/scott/ai_uk/game_specific.c
@@ -362,38 +362,36 @@ void Mysterious64Sysmess(void)
     for (int i = 1; i <= 6; i++) {
         dictword = MemAlloc(len + 1);
         strncpy(dictword, sys[i - 1], GameHeader.WordLength);
-        dictword[len] = '\0';
+        dictword[len] = 0;
         Nouns[i] = dictword;
     }
 
-    Nouns[0] = "ANY\0";
+    Nouns[0] = "ANY";
 
     switch (CurrentGame) {
     case BATON_C64:
-        Nouns[79] = "CAST\0";
-        Verbs[79] = ".\0";
+        Nouns[79] = "CAST";
+        Verbs[79] = ".";
         GameHeader.NumWords = 79;
         break;
     case TIME_MACHINE_C64:
-        Verbs[86] = ".\0";
+        Verbs[86] = ".";
         break;
     case ARROW1_C64:
-        Nouns[82] = ".\0";
+    case PERSEUS_C64:
+        Nouns[82] = ".";
         break;
     case ARROW2_C64:
-        Verbs[80] = ".\0";
+        Verbs[80] = ".";
         break;
     case PULSAR7_C64:
-        Nouns[102] = ".\0";
+        Nouns[102] = ".";
         break;
     case CIRCUS_C64:
-        Nouns[96] = ".\0";
+        Nouns[96] = ".";
         break;
     case FEASIBILITY_C64:
-        Nouns[80] = ".\0";
-        break;
-    case PERSEUS_C64:
-        Nouns[82] = ".\0";
+        Nouns[80] = ".";
         break;
     default:
         break;

--- a/terps/scott/ai_uk/gremlins.c
+++ b/terps/scott/ai_uk/gremlins.c
@@ -188,9 +188,9 @@ void FillInGermanSystemMessages(void)
 
 void LoadExtraGermanGremlinsC64Data(void)
 {
-    Verbs[0] = "AUTO\0";
-    Nouns[0] = "ANY\0";
-    Nouns[28] = "*Y.M.C\0";
+    Verbs[0] = "AUTO";
+    Nouns[0] = "ANY";
+    Nouns[28] = "*Y.M.C";
 
     // These are broken in some versions
     Actions[0].Condition[0] = 1005;
@@ -242,9 +242,9 @@ void LoadExtraGermanGremlinsC64Data(void)
 
 void LoadExtraGermanGremlinsData(void)
 {
-    Verbs[0] = "AUTO\0";
-    Nouns[0] = "ANY\0";
-    Nouns[28] = "*Y.M.C\0";
+    Verbs[0] = "AUTO";
+    Nouns[0] = "ANY";
+    Nouns[28] = "*Y.M.C";
 
     Messages[90] = "Ehe ich etwas anderes mache, much aich erst alles andere fallenlassen. ";
     FillInGermanSystemMessages();

--- a/terps/scott/detectgame.c
+++ b/terps/scott/detectgame.c
@@ -41,10 +41,10 @@ struct dictionaryKey {
 };
 
 struct dictionaryKey dictKeys[] = {
-    { FOUR_LETTER_UNCOMPRESSED, "AUTO\0GO\0", 8 },
-    { THREE_LETTER_UNCOMPRESSED, "AUT\0GO\0", 7 },
-    { FIVE_LETTER_UNCOMPRESSED, "GO\0\0\0\0*CROSS*RUN\0", 17 }, // Claymorgue
-    { FOUR_LETTER_COMPRESSED, "aUTOgO\0", 7 },
+    { FOUR_LETTER_UNCOMPRESSED, "AUTO\0GO", 8 },
+    { THREE_LETTER_UNCOMPRESSED, "AUT\0GO", 7 },
+    { FIVE_LETTER_UNCOMPRESSED, "GO\0\0\0\0*CROSS*RUN", 17 }, // Claymorgue
+    { FOUR_LETTER_COMPRESSED, "aUTOgO", 7 },
     { GERMAN_C64, "gEHENSTEIGE", 11 }, // Gremlins German C64
     { GERMAN, "\xc7"
               "EHENSTEIGE",
@@ -469,8 +469,9 @@ GameIDType TryLoadingOld(struct GameInfo info, int dict_start)
             &tr, &wl, &lt, &mn, &trm))
         return UNKNOWN_GAME;
 
-    if (ni != info.number_of_items || na != info.number_of_actions || nw != info.number_of_words || nr != info.number_of_rooms || mc != info.max_carried) {
-        //        debug_print("Non-matching header\n");
+    if (ni != info.number_of_items || na != info.number_of_actions ||
+        nw != info.number_of_words || nr != info.number_of_rooms ||
+        mc != info.max_carried) {
         return UNKNOWN_GAME;
     }
 
@@ -1189,7 +1190,13 @@ int IsMysterious(void)
 {
     for (int i = 0; games[i].Title != NULL; i++) {
         if (games[i].subtype & MYSTERIOUS) {
-            if (games[i].number_of_items == GameHeader.NumItems && games[i].number_of_actions == GameHeader.NumActions && games[i].number_of_words == GameHeader.NumWords && games[i].number_of_rooms == GameHeader.NumRooms && games[i].max_carried == GameHeader.MaxCarry && games[i].word_length == GameHeader.WordLength && games[i].number_of_messages == GameHeader.NumMessages)
+            if (games[i].number_of_items == GameHeader.NumItems &&
+                games[i].number_of_actions == GameHeader.NumActions &&
+                games[i].number_of_words == GameHeader.NumWords &&
+                games[i].number_of_rooms == GameHeader.NumRooms &&
+                games[i].max_carried == GameHeader.MaxCarry &&
+                games[i].word_length == GameHeader.WordLength &&
+                games[i].number_of_messages == GameHeader.NumMessages)
                 return 1;
         }
     }

--- a/terps/scott/saga/saga.c
+++ b/terps/scott/saga/saga.c
@@ -420,7 +420,7 @@ GameIDType LoadBinaryDatabase(uint8_t *data, size_t length, struct GameInfo info
     do {
         string_length = *(ptr++);
         if (string_length == 0) {
-            rp->Text = ".\0";
+            rp->Text = ".";
         } else {
             rp->Text = MemAlloc(string_length + 1);
             for (int i = 0; i < string_length; i++) {
@@ -441,7 +441,7 @@ GameIDType LoadBinaryDatabase(uint8_t *data, size_t length, struct GameInfo info
     do {
         string_length = *(ptr++);
         if (string_length == 0) {
-            string = ".\0";
+            string = ".";
         } else {
             string = MemAlloc(string_length + 1);
             for (int i = 0; i < string_length; i++) {
@@ -462,7 +462,7 @@ GameIDType LoadBinaryDatabase(uint8_t *data, size_t length, struct GameInfo info
     do {
         string_length = *(ptr++);
         if (string_length == 0) {
-            ip->Text = ".\0";
+            ip->Text = ".";
             ip->AutoGet = NULL;
         } else {
             ip->Text = MemAlloc(string_length + 1);

--- a/terps/scott/ti994a/load_ti99_4a.c
+++ b/terps/scott/ti994a/load_ti99_4a.c
@@ -372,7 +372,7 @@ static uint8_t *LoadTitleScreen(void)
         buf[offset++] = '\n';
     }
 
-    buf[offset] = '\0';
+    buf[offset] = 0;
     uint8_t *result = MemAlloc(offset + 1);
     memcpy(result, buf, offset + 1);
     return result;
@@ -432,7 +432,7 @@ static GameIDType TryLoadingTI994A(struct DATAHEADER dh, int loud)
     do {
         rp->Text = GetTI994AString(dh.p_room_descr, ct);
         if (rp->Text == NULL)
-            rp->Text = ".\0";
+            rp->Text = ".";
         if (loud)
             debug_print("Room %d: %s\n", ct, rp->Text);
         rp->Image = 255;
@@ -447,7 +447,7 @@ static GameIDType TryLoadingTI994A(struct DATAHEADER dh, int loud)
     while (ct < mn + 1) {
         Messages[ct] = GetTI994AString(dh.p_message, ct);
         if (Messages[ct] == NULL)
-            Messages[ct] = ".\0";
+            Messages[ct] = ".";
         if (loud)
             debug_print("Message %d: %s\n", ct, Messages[ct]);
         ct++;
@@ -461,7 +461,7 @@ static GameIDType TryLoadingTI994A(struct DATAHEADER dh, int loud)
     do {
         ip->Text = GetTI994AString(dh.p_obj_descr, ct);
         if (ip->Text == NULL) {
-            ip->Text = ".\0";
+            ip->Text = ".";
             ip->AutoGet = NULL;
         }
         if (ip->Text && ip->Text[0] == '*')
@@ -515,10 +515,10 @@ static GameIDType TryLoadingTI994A(struct DATAHEADER dh, int loud)
     LoadTI994ADict(dh.p_noun_table, dh.num_nouns + 1, Nouns);
 
     for (int i = 1; i <= dh.num_nouns - dh.num_verbs; i++)
-        Verbs[dh.num_verbs + i] = ".\0";
+        Verbs[dh.num_verbs + i] = ".";
 
     for (int i = 1; i <= dh.num_verbs - dh.num_nouns; i++)
-        Nouns[dh.num_nouns + i] = ".\0";
+        Nouns[dh.num_nouns + i] = ".";
 
     if (loud) {
         for (int i = 0; i <= GameHeader.NumWords; i++)


### PR DESCRIPTION
Arthur: Add patches and entrypoints

Bocfel:  Double click support

Athur: Add y offset to lower hints window

Because we use two windows where the original code uses a single one.

Arthur: Hints menu fixes

Arthur uses a single background colour and no graphics.

Bocfel: Z6 menu stuff

Don't leave empty files in temp folder when constructing tiff file name.

Draw "banner poles" all the way down to the bottom of the window by repeating parts of the original image(s).

Look for "arthur.blb", "arthur.mg1", etc if game is Arthur and exact filename match is not found, "journey.blb", etc if it is Journey.

Bocfel autosave update for Arthur

Add all that Arthur needs to autosave

GlkController: If several windows have the same size, use the last

This is for setting the border colour when overlapping Glk windows cover the game view

GlkGraphicsWindow: Change background layer color when changing background

This is visible when resizing.

ImageHandler: Delete image file when purging image

Unless it is a blorb.

Arthur: Make intro "animation" quicker

I like it better like this.

SCOTT: Remove superfluous terminating zeros in strings

Remove some commented stuff, reword some error messages and comments, simplify '\0' as 0.

Bocfel Arthur: Initial VoiceOver support for hint menu

Arthur: Implement setting to redirect text to main window

GlkController: Fix speaking new text

GlkTextBufferWindow: Insertion point should be Zcolor foreground

Try to adjust Z-machine graphic font vertical stretch again

Make "Redirect text to main window" affect quote boxes

Arthur: Properly display fullscreen images

Now they fill the screen.

Arthur: Use two separate booleans for post-autorestore stuff

Because they might be called in any order.

Bocfel: zget_wind_prop: return correct y size for grid windows

This fixes Arthur inventory and status modes.

Register clicks at the very top of the window

Redraw an existing buffer window with current styles, against the Glk spec. This will hopefully help with the z6 colours.

This updates an existing window on-the-fly with the styles that normally would only be applied to a new window. Currently used by the help menu in Arthur.

GlkWindow: Move print attribute calculation to super class

This avoids some duplication. A possible optimization would be to cache this instead of recreating it on every print operation.

GlkController: Update style measure handling

Use the new getCurrentAttributesForStyle method.
I'm not sure if it is a good idea to take Zcolors into account here. I was going to use it in Arthur but it wouldn't work properly, so something might still be broken here.

The colours now work, but code is still a mess.

I'm almost certain this could be simplified. It is supposed to always match the status bar colours, and the status bar handles it just fine without anything like this.

Bocfel Z6: Make colour variables unsigned

This was to make them directly usable with glk_style_measure, which is not used any more, but I guess it does not hurt.

GlkTextGridWindow: Fix background colour on clear

Let's see what this breaks.

Bocfel: screen.c: Fix some magic numbers

Bocfel: Arthur: Don't make upper window reverse video on clear

Bocfel: Update license

Bocfel: Add my hacks on top of the Bocfel 2.2.3 source

GlkTextGridWindow printToWindow: Ignore newlines at end of string

This caused an extra recursive call to printToWindow with an empty string.

GlkGraphicsWindow setBgColor: Fix setting background to zcolor_Default

I guess according to spec, the default background colour of a graphics window is always white. But it works better for Arthur this way.

GlkStyle attributesWithHints: handle empty hints dict

Arthur calls this with an empty hints directory. Not sure why.

Bocfel: Arthur: Don't redraw graphics on every turn

Only on arrange events and draw commands

Bocfel: Don't echo commands twice to Arthur transcript

Bocfel: Arthur: Ending screen

After the final action, the text buffer should
fill the screen, without a status bar.

Bocfel: Fix stray characters in Arthur status bar

Redraw entire status on every turn.

Bocfel: Fix out-of-bounds read

Bocfel: Fix centered THE END in Arthur

We patch the code to replace  <HLIGHT ,H-BOLD>
call with bold fixed-width, which we have mapped to style_User1, (set to bold, centered text) which matches the style of the original centered "THE END" text.

Bocfel: entrypoints: Don't keep looking if we are past PC

The entrypoints are in rising order, so if we find one that is higher than the current program counter, we have gone too far.