### PR TITLE
Add support for macOS "Now Playing" with `MPNowPlayingInfoCenter`

### DIFF
--- a/Spatterlight.xcodeproj/project.pbxproj
+++ b/Spatterlight.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		559BE460270F7BD800B93F2C /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6D79B0D9223262CA008C9CB7 /* Cocoa.framework */; };
 		55A01EDD2B189325003D7C18 /* BlorbResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A01EDC2B189325003D7C18 /* BlorbResource.swift */; };
 		55A01EE02B1898E9003D7C18 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6D79B0DE223262CA008C9CB7 /* Foundation.framework */; };
+		61C07B5A3024065800388340 /* NowPlayingCoordinator.m in Sources */ = {isa = PBXBuildFile; fileRef = 61C07B593024065800388340 /* NowPlayingCoordinator.m */; };
 		61E6BE2FF01D3415E4034249 /* scnpcs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 96800C7329F2706EB62F4306 /* scnpcs.cpp */; };
 		662C36FF62B14FED8CEE7729 /* GlkTextBufferWindow+Hyperlinks.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B97A332BA494DD98C1A1131 /* GlkTextBufferWindow+Hyperlinks.m */; };
 		6721E9E796626F0B9D599492 /* scinterf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8EE0E82499061DB6D3D5ED73 /* scinterf.cpp */; };
@@ -768,6 +769,7 @@
 		C37E676026E988000005873E /* MIDIPlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = C37E675E26E987FF0005873E /* MIDIPlayer.m */; };
 		C37E676226E992440005873E /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C37E676126E992440005873E /* AudioToolbox.framework */; };
 		C37E676426E992590005873E /* AudioUnit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C37E676326E992590005873E /* AudioUnit.framework */; };
+		A10F00013024070000388340 /* MediaPlayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A10F00023024070000388340 /* MediaPlayer.framework */; };
 		C37EC5A02847AA3C0084B841 /* gameinfo.c in Sources */ = {isa = PBXBuildFile; fileRef = C37EC58D2847A9E00084B841 /* gameinfo.c */; };
 		C37EC5A12847AA3C0084B841 /* plusmain.c in Sources */ = {isa = PBXBuildFile; fileRef = C37EC5902847A9E00084B841 /* plusmain.c */; };
 		C37EC5A32847AA760084B841 /* libglkmain.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 961CCEB709F2396500528FF9 /* libglkmain.a */; };
@@ -1781,6 +1783,8 @@
 		55A01EDB2B188178003D7C18 /* sha2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sha2.h; sourceTree = "<group>"; };
 		55A01EDC2B189325003D7C18 /* BlorbResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlorbResource.swift; sourceTree = "<group>"; };
 		5988597D3F5747EF835AACB3 /* GlkTextBufferWindow+Output.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "GlkTextBufferWindow+Output.m"; sourceTree = "<group>"; };
+		61C07B573024065000388340 /* NowPlayingCoordinator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NowPlayingCoordinator.h; sourceTree = "<group>"; };
+		61C07B593024065800388340 /* NowPlayingCoordinator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NowPlayingCoordinator.m; sourceTree = "<group>"; };
 		621D71B0003145CA87C1B340 /* GlkTextBufferWindow+Autorestore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "GlkTextBufferWindow+Autorestore.m"; sourceTree = "<group>"; };
 		6408B5CA09BAAF2505BD12D5 /* a5expr.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = a5expr.cpp; sourceTree = "<group>"; };
 		682A6ED470E4107F583B7D84 /* os_glk.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = os_glk.cpp; sourceTree = "<group>"; };
@@ -3343,6 +3347,7 @@
 		C37E675F26E987FF0005873E /* MIDIPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MIDIPlayer.h; sourceTree = "<group>"; };
 		C37E676126E992440005873E /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		C37E676326E992590005873E /* AudioUnit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioUnit.framework; path = System/Library/Frameworks/AudioUnit.framework; sourceTree = SDKROOT; };
+		A10F00023024070000388340 /* MediaPlayer.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MediaPlayer.framework; path = System/Library/Frameworks/MediaPlayer.framework; sourceTree = SDKROOT; };
 		C37EC58D2847A9E00084B841 /* gameinfo.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = gameinfo.c; sourceTree = "<group>"; };
 		C37EC5902847A9E00084B841 /* plusmain.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = plusmain.c; sourceTree = "<group>"; };
 		C37EC5912847A9E00084B841 /* gameinfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = gameinfo.h; sourceTree = "<group>"; };
@@ -3855,6 +3860,7 @@
 				C31AF2FA271652A0007B7120 /* CoreSpotlight.framework in Frameworks */,
 				C344B2CC26E4DA87004B0A8F /* SFBAudioEngine.framework in Frameworks */,
 				C37E676426E992590005873E /* AudioUnit.framework in Frameworks */,
+				A10F00013024070000388340 /* MediaPlayer.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4904,6 +4910,7 @@
 				C31AF2F5271651C4007B7120 /* CoreServices.framework */,
 				C37E676326E992590005873E /* AudioUnit.framework */,
 				C37E676126E992440005873E /* AudioToolbox.framework */,
+				A10F00023024070000388340 /* MediaPlayer.framework */,
 				C38C226025CC7EB3004C4D68 /* QuickLook.framework */,
 				6D79B0D9223262CA008C9CB7 /* Cocoa.framework */,
 				6D7677FE22B1430700C80DDE /* QuartzCore.framework */,
@@ -6063,6 +6070,8 @@
 				C37E675C26E9844D0005873E /* MIDIChannel.m */,
 				C37E675F26E987FF0005873E /* MIDIPlayer.h */,
 				C37E675E26E987FF0005873E /* MIDIPlayer.m */,
+				61C07B573024065000388340 /* NowPlayingCoordinator.h */,
+				61C07B593024065800388340 /* NowPlayingCoordinator.m */,
 			);
 			path = Sounds;
 			sourceTree = "<group>";
@@ -8313,6 +8322,7 @@
 				144A2FE274534FB4993C777A /* GlkTextBufferWindow+Input.m in Sources */,
 				B7145202EAC047AD8BB455D0 /* GlkTextBufferWindow+Output.m in Sources */,
 				839AE40E479A4A7CBE84ADFE /* GlkTextBufferWindow+Scrolling.m in Sources */,
+				61C07B5A3024065800388340 /* NowPlayingCoordinator.m in Sources */,
 				8ACEDF01792C4B3AACF80444 /* GlkTextBufferWindow+Speech.m in Sources */,
 				A4C48ACBD56A42C3ADB4F649 /* GlkTextBufferWindow+Styles.m in Sources */,
 				C3AD640926176589008614C5 /* MarginContainer.m in Sources */,

--- a/application/Sounds/GlkSoundChannel.h
+++ b/application/Sounds/GlkSoundChannel.h
@@ -36,6 +36,15 @@ typedef NS_ENUM(NSInteger, GlkSoundChannelStatus) {
 @property int name;
 @property (weak) SoundHandler *handler;
 
+/// YES while this channel holds a music-like sound (looping or >5s).
+@property BOOL claimsNowPlaying;
+/// Decoded length in seconds (0 if unknown). Not multiplied by repeats.
+@property NSTimeInterval nowPlayingDuration;
+/// YES when the current sound was started with infinite repeats.
+@property BOOL nowPlayingLooping;
+
+- (BOOL)isPaused;
+
 - (instancetype)initWithHandler:(SoundHandler *)handler name:(int)name volume:(glui32)vol;
 - (oneway void)setVolume:(glui32) vol duration:(glui32)dur notification:(glui32)noti;
 - (BOOL)playSound:(glsi32) sound countOfRepeats:(glsi32)repeat notification:(glui32)noti;

--- a/application/Sounds/GlkSoundChannel.h
+++ b/application/Sounds/GlkSoundChannel.h
@@ -37,7 +37,8 @@ typedef NS_ENUM(NSInteger, GlkSoundChannelStatus) {
 @property (weak) SoundHandler *handler;
 
 /// YES while this channel holds a music-like sound (looping or >5s).
-@property BOOL claimsNowPlaying;
+/// Derived from status, nowPlayingLooping and nowPlayingDuration.
+@property (readonly) BOOL claimsNowPlaying;
 /// Decoded length in seconds (0 if unknown). Not multiplied by repeats.
 @property NSTimeInterval nowPlayingDuration;
 /// YES when the current sound was started with infinite repeats.
@@ -48,6 +49,9 @@ typedef NS_ENUM(NSInteger, GlkSoundChannelStatus) {
 - (instancetype)initWithHandler:(SoundHandler *)handler name:(int)name volume:(glui32)vol;
 - (oneway void)setVolume:(glui32) vol duration:(glui32)dur notification:(glui32)noti;
 - (BOOL)playSound:(glsi32) sound countOfRepeats:(glsi32)repeat notification:(glui32)noti;
+/// The actual playback work; subclasses override this rather than playSound:,
+/// which wraps it in a single Now Playing update.
+- (BOOL)playSoundInternal:(glsi32) sound countOfRepeats:(glsi32)repeat notification:(glui32)noti;
 - (oneway void)stop;
 - (oneway void)pause;
 - (oneway void)unpause;

--- a/application/Sounds/GlkSoundChannel.mm
+++ b/application/Sounds/GlkSoundChannel.mm
@@ -95,6 +95,9 @@ static SFB::InputSource::unique_ptr CreateWithCFData(CFDataRef bytes, bool copyB
 
 - (BOOL)playSound:(glsi32)snd countOfRepeats:(glsi32)areps notification:(glui32)anot {
     _status = GlkSoundChannelStatusSound;
+    _claimsNowPlaying = NO;
+    _nowPlayingDuration = 0;
+    _nowPlayingLooping = NO;
 
     GlkSoundBlorbFormatType type;
 
@@ -106,8 +109,10 @@ static SFB::InputSource::unique_ptr CreateWithCFData(CFDataRef bytes, bool copyB
         _player->Stop();
     }
 
-    if (areps == 0 || snd == -1)
+    if (areps == 0 || snd == -1) {
+        [_handler nowPlayingStateDidChange];
         return NO;
+    }
 
     /* load sound resource into memory */
     type = [_handler loadSoundResourceFromSound:snd data:&buf];
@@ -120,6 +125,7 @@ static SFB::InputSource::unique_ptr CreateWithCFData(CFDataRef bytes, bool copyB
 
     if (!mimeString) {
         NSLog(@"schannel_play_ext: unknown resource type (%ld).", type);
+        [_handler nowPlayingStateDidChange];
         return NO;
     }
 
@@ -150,15 +156,24 @@ static SFB::InputSource::unique_ptr CreateWithCFData(CFDataRef bytes, bool copyB
 
     [self setVolume];
 
+    BOOL looping = (areps == -1);
+
     if (areps != -1) {
         glui32 blocknotify = notify;
         glsi32 blockresid = resid;
         GlkSoundChannel __weak *weakSelf = self;
         _player->SetRenderingFinishedBlock(^(const SFB::Audio::Decoder& /*decoder*/){
             dispatch_async(dispatch_get_main_queue(), ^{
-                weakSelf.status = GlkSoundChannelStatusIdle;
+                GlkSoundChannel *strongSelf = weakSelf;
+                if (!strongSelf)
+                    return;
+                strongSelf.status = GlkSoundChannelStatusIdle;
+                strongSelf.claimsNowPlaying = NO;
+                strongSelf.nowPlayingDuration = 0;
+                strongSelf.nowPlayingLooping = NO;
+                [strongSelf.handler nowPlayingStateDidChange];
                 if (blocknotify)
-                    [weakSelf.handler handleSoundNotification:blocknotify withSound:blockresid];
+                    [strongSelf.handler handleSoundNotification:blocknotify withSound:blockresid];
             });
         });
     }
@@ -169,12 +184,24 @@ static SFB::InputSource::unique_ptr CreateWithCFData(CFDataRef bytes, bool copyB
     if (!decoder->Open(&error))
         NSLog(@"GlkSoundChannel: Could not open decoder (format:%@) %@", mimeString, error);
     SInt64 frames = decoder->GetTotalFrames();
+    Float64 sampleRate = decoder->GetFormat().mSampleRate;
+    if (frames > 0 && sampleRate > 0)
+        _nowPlayingDuration = (NSTimeInterval)frames / sampleRate;
+    _nowPlayingLooping = looping;
+    _claimsNowPlaying = looping || _nowPlayingDuration > 5.0;
+
     auto loopableRegionDecoder = SFB::Audio::LoopableRegionDecoder::CreateForDecoderRegion((std::move(decoder)), 0, (UInt32)frames, (UInt32)areps - 1);
     if (paused)
         _player->Enqueue(loopableRegionDecoder);
     else
         _player->Play(loopableRegionDecoder);
+
+    [_handler nowPlayingStateDidChange];
     return YES;
+}
+
+- (BOOL)isPaused {
+    return paused != 0;
 }
 
 - (void)stop {
@@ -184,10 +211,14 @@ static SFB::InputSource::unique_ptr CreateWithCFData(CFDataRef bytes, bool copyB
         _player->Stop();
     }
     [self cleanup];
+    [_handler nowPlayingStateDidChange];
 }
 
 - (void)pause {
     paused = YES;
+    // Publish paused state before stopping output so macOS does not treat
+    // the ensuing silence as a full stop / session teardown.
+    [_handler nowPlayingStateDidChange];
     if (_player)
         _player->Pause();
 }
@@ -195,10 +226,12 @@ static SFB::InputSource::unique_ptr CreateWithCFData(CFDataRef bytes, bool copyB
 - (void)unpause {
     paused = NO;
     BOOL result;
-    if (!_player) {
+    if (!_player || _player->IsStopped()) {
+        // No live decoder (or player fully stopped) — restart the same sound.
         result = [self playSound:resid countOfRepeats:loop notification:notify];
     } else {
         result = _player->Play();
+        [_handler nowPlayingStateDidChange];
     }
     if (!result)
         NSLog(@"GlkSoundChannel: Failed to unpause sound %d", resid);
@@ -206,6 +239,9 @@ static SFB::InputSource::unique_ptr CreateWithCFData(CFDataRef bytes, bool copyB
 
 - (void)cleanup {
     _status = GlkSoundChannelStatusIdle;
+    _claimsNowPlaying = NO;
+    _nowPlayingDuration = 0;
+    _nowPlayingLooping = NO;
     if (timer)
         [timer invalidate];
     timer = nil;

--- a/application/Sounds/GlkSoundChannel.mm
+++ b/application/Sounds/GlkSoundChannel.mm
@@ -94,8 +94,13 @@ static SFB::InputSource::unique_ptr CreateWithCFData(CFDataRef bytes, bool copyB
 }
 
 - (BOOL)playSound:(glsi32)snd countOfRepeats:(glsi32)areps notification:(glui32)anot {
+    BOOL result = [self playSoundInternal:snd countOfRepeats:areps notification:anot];
+    [_handler nowPlayingStateDidChange];
+    return result;
+}
+
+- (BOOL)playSoundInternal:(glsi32)snd countOfRepeats:(glsi32)areps notification:(glui32)anot {
     _status = GlkSoundChannelStatusSound;
-    _claimsNowPlaying = NO;
     _nowPlayingDuration = 0;
     _nowPlayingLooping = NO;
 
@@ -109,10 +114,8 @@ static SFB::InputSource::unique_ptr CreateWithCFData(CFDataRef bytes, bool copyB
         _player->Stop();
     }
 
-    if (areps == 0 || snd == -1) {
-        [_handler nowPlayingStateDidChange];
+    if (areps == 0 || snd == -1)
         return NO;
-    }
 
     /* load sound resource into memory */
     type = [_handler loadSoundResourceFromSound:snd data:&buf];
@@ -125,7 +128,6 @@ static SFB::InputSource::unique_ptr CreateWithCFData(CFDataRef bytes, bool copyB
 
     if (!mimeString) {
         NSLog(@"schannel_play_ext: unknown resource type (%ld).", type);
-        [_handler nowPlayingStateDidChange];
         return NO;
     }
 
@@ -168,9 +170,6 @@ static SFB::InputSource::unique_ptr CreateWithCFData(CFDataRef bytes, bool copyB
                 if (!strongSelf)
                     return;
                 strongSelf.status = GlkSoundChannelStatusIdle;
-                strongSelf.claimsNowPlaying = NO;
-                strongSelf.nowPlayingDuration = 0;
-                strongSelf.nowPlayingLooping = NO;
                 [strongSelf.handler nowPlayingStateDidChange];
                 if (blocknotify)
                     [strongSelf.handler handleSoundNotification:blocknotify withSound:blockresid];
@@ -188,7 +187,6 @@ static SFB::InputSource::unique_ptr CreateWithCFData(CFDataRef bytes, bool copyB
     if (frames > 0 && sampleRate > 0)
         _nowPlayingDuration = (NSTimeInterval)frames / sampleRate;
     _nowPlayingLooping = looping;
-    _claimsNowPlaying = looping || _nowPlayingDuration > 5.0;
 
     auto loopableRegionDecoder = SFB::Audio::LoopableRegionDecoder::CreateForDecoderRegion((std::move(decoder)), 0, (UInt32)frames, (UInt32)areps - 1);
     if (paused)
@@ -196,8 +194,12 @@ static SFB::InputSource::unique_ptr CreateWithCFData(CFDataRef bytes, bool copyB
     else
         _player->Play(loopableRegionDecoder);
 
-    [_handler nowPlayingStateDidChange];
     return YES;
+}
+
+- (BOOL)claimsNowPlaying {
+    return _status != GlkSoundChannelStatusIdle &&
+           (_nowPlayingLooping || _nowPlayingDuration > 5.0);
 }
 
 - (BOOL)isPaused {
@@ -239,9 +241,6 @@ static SFB::InputSource::unique_ptr CreateWithCFData(CFDataRef bytes, bool copyB
 
 - (void)cleanup {
     _status = GlkSoundChannelStatusIdle;
-    _claimsNowPlaying = NO;
-    _nowPlayingDuration = 0;
-    _nowPlayingLooping = NO;
     if (timer)
         [timer invalidate];
     timer = nil;

--- a/application/Sounds/MIDIChannel.m
+++ b/application/Sounds/MIDIChannel.m
@@ -12,9 +12,8 @@
 
 @implementation MIDIChannel
 
-- (BOOL)playSound:(glsi32)snd countOfRepeats:(glsi32)areps notification:(glui32)anot {
+- (BOOL)playSoundInternal:(glsi32)snd countOfRepeats:(glsi32)areps notification:(glui32)anot {
     self.status = GlkSoundChannelStatusSound;
-    self.claimsNowPlaying = NO;
     self.nowPlayingDuration = 0;
     self.nowPlayingLooping = NO;
 
@@ -26,18 +25,14 @@
         [_player stop];
     }
 
-    if (areps == 0 || snd == -1) {
-        [self.handler nowPlayingStateDidChange];
+    if (areps == 0 || snd == -1)
         return NO;
-    }
 
     /* load sound resource into memory */
     type = [self.handler loadSoundResourceFromSound:snd data:&dat];
 
-    if (type != GlkSoundBlorbFormatMIDI) {
-        [self.handler nowPlayingStateDidChange];
+    if (type != GlkSoundBlorbFormatMIDI)
         return NO;
-    }
 
     notify = anot;
     resid = snd;
@@ -47,10 +42,8 @@
 
     [_player setVolume:volume];
 
-    BOOL looping = (areps == -1);
     self.nowPlayingDuration = _player.duration;
-    self.nowPlayingLooping = looping;
-    self.claimsNowPlaying = looping || self.nowPlayingDuration > 5.0;
+    self.nowPlayingLooping = (areps == -1);
 
     if (areps != -1) {
         MIDIChannel __weak *weakSelf = self;
@@ -62,9 +55,6 @@
                 MIDIChannel *strongSelf = weakSelf;
                 if (strongSelf && --strongSelf->loop < 1) {
                     strongSelf.status = GlkSoundChannelStatusIdle;
-                    strongSelf.claimsNowPlaying = NO;
-                    strongSelf.nowPlayingDuration = 0;
-                    strongSelf.nowPlayingLooping = NO;
                     [blockHandler nowPlayingStateDidChange];
                     if (blocknotify)
                         [blockHandler handleSoundNotification:blocknotify withSound:blockresid];
@@ -78,7 +68,6 @@
     if (!paused)
         [_player play];
 
-    [self.handler nowPlayingStateDidChange];
     return YES;
 }
 

--- a/application/Sounds/MIDIChannel.m
+++ b/application/Sounds/MIDIChannel.m
@@ -14,6 +14,9 @@
 
 - (BOOL)playSound:(glsi32)snd countOfRepeats:(glsi32)areps notification:(glui32)anot {
     self.status = GlkSoundChannelStatusSound;
+    self.claimsNowPlaying = NO;
+    self.nowPlayingDuration = 0;
+    self.nowPlayingLooping = NO;
 
     NSData *dat = nil;
     GlkSoundBlorbFormatType type;
@@ -23,14 +26,18 @@
         [_player stop];
     }
 
-    if (areps == 0 || snd == -1)
+    if (areps == 0 || snd == -1) {
+        [self.handler nowPlayingStateDidChange];
         return NO;
+    }
 
     /* load sound resource into memory */
     type = [self.handler loadSoundResourceFromSound:snd data:&dat];
 
-    if (type != GlkSoundBlorbFormatMIDI)
+    if (type != GlkSoundBlorbFormatMIDI) {
+        [self.handler nowPlayingStateDidChange];
         return NO;
+    }
 
     notify = anot;
     resid = snd;
@@ -39,6 +46,11 @@
     _player = [[MIDIPlayer alloc] initWithData:dat];
 
     [_player setVolume:volume];
+
+    BOOL looping = (areps == -1);
+    self.nowPlayingDuration = _player.duration;
+    self.nowPlayingLooping = looping;
+    self.claimsNowPlaying = looping || self.nowPlayingDuration > 5.0;
 
     if (areps != -1) {
         MIDIChannel __weak *weakSelf = self;
@@ -50,6 +62,10 @@
                 MIDIChannel *strongSelf = weakSelf;
                 if (strongSelf && --strongSelf->loop < 1) {
                     strongSelf.status = GlkSoundChannelStatusIdle;
+                    strongSelf.claimsNowPlaying = NO;
+                    strongSelf.nowPlayingDuration = 0;
+                    strongSelf.nowPlayingLooping = NO;
+                    [blockHandler nowPlayingStateDidChange];
                     if (blocknotify)
                         [blockHandler handleSoundNotification:blocknotify withSound:blockresid];
                 }
@@ -61,6 +77,8 @@
 
     if (!paused)
         [_player play];
+
+    [self.handler nowPlayingStateDidChange];
     return YES;
 }
 
@@ -70,10 +88,12 @@
         [_player stop];
     }
     [self cleanup];
+    [self.handler nowPlayingStateDidChange];
 }
 
 - (void)pause {
     paused = YES;
+    [self.handler nowPlayingStateDidChange];
     if (_player)
         [_player pause];
 }
@@ -86,6 +106,7 @@
             NSLog(@"MIDIChannel: Failed to unpause sound %d", resid);
     } else {
         [_player play];
+        [self.handler nowPlayingStateDidChange];
     }
 }
 

--- a/application/Sounds/MIDIPlayer.h
+++ b/application/Sounds/MIDIPlayer.h
@@ -10,6 +10,8 @@
 @interface MIDIPlayer : NSObject
 
 @property (nonatomic) double progress;
+/// Sequence length in seconds (longest track), or 0 if unknown.
+@property (nonatomic, readonly) NSTimeInterval duration;
 
 - (instancetype)initWithData:(NSData *)data;
 

--- a/application/Sounds/MIDIPlayer.m
+++ b/application/Sounds/MIDIPlayer.m
@@ -23,6 +23,8 @@
 
     MusicPlayer player;
     MusicSequence sequence;
+    MusicTimeStamp pausedTime;
+    BOOL hasPausedTime;
 }
 
 @end
@@ -31,6 +33,8 @@
 
 - (instancetype)initWithData:(NSData *)data {
     if (self = [super init]) {
+        hasPausedTime = NO;
+        pausedTime = 0;
         [self createGraph];
         [self startGraph];
         [self loadData:data];
@@ -114,6 +118,28 @@
     NewMusicPlayer(&player);
     MusicPlayerSetSequence(player, sequence);
     MusicPlayerPreroll(player);
+
+    _duration = 0;
+    UInt32 numberOfTracks = 0;
+    if (MusicSequenceGetTrackCount(sequence, &numberOfTracks) == noErr) {
+        MusicTimeStamp longest = 0;
+        for (UInt32 i = 0; i < numberOfTracks; i++) {
+            MusicTrack track = NULL;
+            MusicTimeStamp trackLen = 0;
+            UInt32 trackLenLen = sizeof(trackLen);
+            if (MusicSequenceGetIndTrack(sequence, i, &track) != noErr)
+                continue;
+            if (MusicTrackGetProperty(track, kSequenceTrackProperty_TrackLength, &trackLen, &trackLenLen) != noErr)
+                continue;
+            if (trackLen > longest)
+                longest = trackLen;
+        }
+        if (longest > 0) {
+            Float64 seconds = 0;
+            if (MusicSequenceGetSecondsForBeats(sequence, longest, &seconds) == noErr)
+                _duration = (NSTimeInterval)seconds;
+        }
+    }
 }
 
 - (void)loop:(NSInteger)repeats {
@@ -139,12 +165,18 @@
 
 - (void)play {
     [self startGraph];
+    if (hasPausedTime) {
+        MusicPlayerSetTime(player, pausedTime);
+        hasPausedTime = NO;
+    }
     MusicPlayerStart(player);
 }
 
 - (void)pause {
-    [self stopGraph];
+    pausedTime = 0;
+    hasPausedTime = (MusicPlayerGetTime(player, &pausedTime) == noErr);
     MusicPlayerStop(player);
+    [self stopGraph];
 }
 
 - (void)stop {

--- a/application/Sounds/NowPlayingCoordinator.h
+++ b/application/Sounds/NowPlayingCoordinator.h
@@ -1,0 +1,24 @@
+//
+//  NowPlayingCoordinator.h
+//  Spatterlight
+//
+
+#import <Foundation/Foundation.h>
+
+@class SoundHandler;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NowPlayingCoordinator : NSObject
+
+- (instancetype)initWithSoundHandler:(SoundHandler *)handler;
+
+/// Recompute Now Playing state from the handler's channels.
+- (void)refresh;
+
+/// Clear Now Playing (stopped) and drop metadata.
+- (void)clear;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/application/Sounds/NowPlayingCoordinator.h
+++ b/application/Sounds/NowPlayingCoordinator.h
@@ -9,15 +9,19 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/// Publishes system Now Playing (MPNowPlayingInfoCenter) for whichever
+/// SoundHandler most recently had music-like sound. One shared instance
+/// arbitrates between game windows.
 @interface NowPlayingCoordinator : NSObject
 
-- (instancetype)initWithSoundHandler:(SoundHandler *)handler;
++ (NowPlayingCoordinator *)shared;
 
-/// Recompute Now Playing state from the handler's channels.
-- (void)refresh;
+/// Recompute Now Playing from this handler's channels, taking over or
+/// releasing the system session as appropriate.
+- (void)refreshForHandler:(SoundHandler *)handler;
 
-/// Clear Now Playing (stopped) and drop metadata.
-- (void)clear;
+/// Clear system Now Playing if this handler owns the session.
+- (void)clearForHandler:(SoundHandler *)handler;
 
 @end
 

--- a/application/Sounds/NowPlayingCoordinator.m
+++ b/application/Sounds/NowPlayingCoordinator.m
@@ -16,102 +16,80 @@
 #import "Image.h"
 
 @interface NowPlayingCoordinator ()
-@property (weak) SoundHandler *handler;
-/// YES while this coordinator last published eligible Now Playing info.
-@property BOOL ownsNowPlayingSession;
+/// The SoundHandler that currently owns system Now Playing.
+@property (weak, nullable) SoundHandler *activeHandler;
 @end
 
 @implementation NowPlayingCoordinator
 
-/// The coordinator that currently owns system Now Playing (weak).
-static __weak NowPlayingCoordinator *sActiveCoordinator;
-
-- (instancetype)initWithSoundHandler:(SoundHandler *)handler {
-    if (self = [super init]) {
-        _handler = handler;
-        [NowPlayingCoordinator setupRemoteCommandsIfNeeded];
-    }
-    return self;
-}
-
-+ (void)setupRemoteCommandsIfNeeded {
++ (NowPlayingCoordinator *)shared {
+    static NowPlayingCoordinator *shared;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        MPRemoteCommandCenter *center = [MPRemoteCommandCenter sharedCommandCenter];
-
-        [center.playCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent *event) {
-#pragma unused(event)
-            NowPlayingCoordinator *active = sActiveCoordinator;
-            [active.handler unpauseEligibleNowPlayingChannels];
-            [active refresh];
-            return MPRemoteCommandHandlerStatusSuccess;
-        }];
-
-        [center.pauseCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent *event) {
-#pragma unused(event)
-            NowPlayingCoordinator *active = sActiveCoordinator;
-            [active.handler pauseEligibleNowPlayingChannels];
-            [active refresh];
-            return MPRemoteCommandHandlerStatusSuccess;
-        }];
-
-        [center.togglePlayPauseCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent *event) {
-#pragma unused(event)
-            NowPlayingCoordinator *active = sActiveCoordinator;
-            SoundHandler *handler = active.handler;
-            if ([handler hasPlayingEligibleNowPlayingChannel])
-                [handler pauseEligibleNowPlayingChannels];
-            else
-                [handler unpauseEligibleNowPlayingChannels];
-            [active refresh];
-            return MPRemoteCommandHandlerStatusSuccess;
-        }];
-
-        // Pause must not be treated as stop: keep position and session.
-        center.stopCommand.enabled = NO;
-        center.nextTrackCommand.enabled = NO;
-        center.previousTrackCommand.enabled = NO;
-        center.seekForwardCommand.enabled = NO;
-        center.seekBackwardCommand.enabled = NO;
-        center.changePlaybackPositionCommand.enabled = NO;
+        shared = [NowPlayingCoordinator new];
+        [shared setupRemoteCommands];
     });
+    return shared;
 }
 
-- (void)clearNowPlayingInfo {
+- (void)setupRemoteCommands {
+    MPRemoteCommandCenter *center = [MPRemoteCommandCenter sharedCommandCenter];
+    NowPlayingCoordinator __weak *weakSelf = self;
+
+    // The pause/unpause calls below notify the handler, which refreshes us,
+    // so no explicit refresh is needed here.
+    [center.playCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent *event) {
+#pragma unused(event)
+        [weakSelf.activeHandler unpauseEligibleNowPlayingChannels];
+        return MPRemoteCommandHandlerStatusSuccess;
+    }];
+
+    [center.pauseCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent *event) {
+#pragma unused(event)
+        [weakSelf.activeHandler pauseEligibleNowPlayingChannels];
+        return MPRemoteCommandHandlerStatusSuccess;
+    }];
+
+    [center.togglePlayPauseCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent *event) {
+#pragma unused(event)
+        SoundHandler *handler = weakSelf.activeHandler;
+        if ([handler hasPlayingEligibleNowPlayingChannel])
+            [handler pauseEligibleNowPlayingChannels];
+        else
+            [handler unpauseEligibleNowPlayingChannels];
+        return MPRemoteCommandHandlerStatusSuccess;
+    }];
+
+    // Pause must not be treated as stop: keep position and session.
+    center.stopCommand.enabled = NO;
+    center.nextTrackCommand.enabled = NO;
+    center.previousTrackCommand.enabled = NO;
+    center.seekForwardCommand.enabled = NO;
+    center.seekBackwardCommand.enabled = NO;
+    center.changePlaybackPositionCommand.enabled = NO;
+}
+
+- (void)clearForHandler:(SoundHandler *)handler {
+    // Never let an idle handler wipe another game window's session. If the
+    // owning handler is gone (activeHandler nilled by ARC), allow the clear.
+    if (self.activeHandler != nil && self.activeHandler != handler)
+        return;
+
+    self.activeHandler = nil;
     MPNowPlayingInfoCenter *infoCenter = [MPNowPlayingInfoCenter defaultCenter];
     infoCenter.nowPlayingInfo = nil;
     infoCenter.playbackState = MPNowPlayingPlaybackStateStopped;
 }
 
-- (void)clear {
-    // Only clear the system UI if we own the session; otherwise another
-    // game window's idle SoundHandler would wipe a paused track.
-    if (!_ownsNowPlayingSession && sActiveCoordinator != self)
-        return;
-
-    _ownsNowPlayingSession = NO;
-    if (sActiveCoordinator == self)
-        sActiveCoordinator = nil;
-    [self clearNowPlayingInfo];
-}
-
-- (void)refresh {
-    SoundHandler *handler = _handler;
-    if (!handler) {
-        [self clear];
-        return;
-    }
-
-    BOOL anyEligible = NO;
+- (void)refreshForHandler:(SoundHandler *)handler {
     BOOL anyPlaying = NO;
     BOOL anyPaused = NO;
     NSTimeInterval duration = 0;
     BOOL looping = NO;
 
     for (GlkSoundChannel *chan in handler.glkchannels.allValues) {
-        if (!chan.claimsNowPlaying || chan.status == GlkSoundChannelStatusIdle)
+        if (!chan.claimsNowPlaying)
             continue;
-        anyEligible = YES;
         if (chan.isPaused)
             anyPaused = YES;
         else
@@ -122,16 +100,12 @@ static __weak NowPlayingCoordinator *sActiveCoordinator;
             duration = chan.nowPlayingDuration;
     }
 
-    if (!anyEligible) {
-        // Only tear down system Now Playing if *this* handler had claimed it.
-        // Other SoundHandlers (other game windows) must not wipe a paused session.
-        if (_ownsNowPlayingSession)
-            [self clear];
+    if (!anyPlaying && !anyPaused) {
+        [self clearForHandler:handler];
         return;
     }
 
-    _ownsNowPlayingSession = YES;
-    sActiveCoordinator = self;
+    self.activeHandler = handler;
 
     NSMutableDictionary *info = [NSMutableDictionary dictionary];
 
@@ -168,12 +142,8 @@ static __weak NowPlayingCoordinator *sActiveCoordinator;
 
     MPNowPlayingInfoCenter *infoCenter = [MPNowPlayingInfoCenter defaultCenter];
     infoCenter.nowPlayingInfo = info;
-    if (anyPlaying)
-        infoCenter.playbackState = MPNowPlayingPlaybackStatePlaying;
-    else if (anyPaused)
-        infoCenter.playbackState = MPNowPlayingPlaybackStatePaused;
-    else
-        infoCenter.playbackState = MPNowPlayingPlaybackStateStopped;
+    infoCenter.playbackState = anyPlaying ? MPNowPlayingPlaybackStatePlaying
+                                          : MPNowPlayingPlaybackStatePaused;
 }
 
 @end

--- a/application/Sounds/NowPlayingCoordinator.m
+++ b/application/Sounds/NowPlayingCoordinator.m
@@ -1,0 +1,179 @@
+//
+//  NowPlayingCoordinator.m
+//  Spatterlight
+//
+
+#import "NowPlayingCoordinator.h"
+
+#import <AppKit/AppKit.h>
+#import <MediaPlayer/MediaPlayer.h>
+
+#import "SoundHandler.h"
+#import "GlkSoundChannel.h"
+#import "GlkController.h"
+#import "Game.h"
+#import "Metadata.h"
+#import "Image.h"
+
+@interface NowPlayingCoordinator ()
+@property (weak) SoundHandler *handler;
+/// YES while this coordinator last published eligible Now Playing info.
+@property BOOL ownsNowPlayingSession;
+@end
+
+@implementation NowPlayingCoordinator
+
+/// The coordinator that currently owns system Now Playing (weak).
+static __weak NowPlayingCoordinator *sActiveCoordinator;
+
+- (instancetype)initWithSoundHandler:(SoundHandler *)handler {
+    if (self = [super init]) {
+        _handler = handler;
+        [NowPlayingCoordinator setupRemoteCommandsIfNeeded];
+    }
+    return self;
+}
+
++ (void)setupRemoteCommandsIfNeeded {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        MPRemoteCommandCenter *center = [MPRemoteCommandCenter sharedCommandCenter];
+
+        [center.playCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent *event) {
+#pragma unused(event)
+            NowPlayingCoordinator *active = sActiveCoordinator;
+            [active.handler unpauseEligibleNowPlayingChannels];
+            [active refresh];
+            return MPRemoteCommandHandlerStatusSuccess;
+        }];
+
+        [center.pauseCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent *event) {
+#pragma unused(event)
+            NowPlayingCoordinator *active = sActiveCoordinator;
+            [active.handler pauseEligibleNowPlayingChannels];
+            [active refresh];
+            return MPRemoteCommandHandlerStatusSuccess;
+        }];
+
+        [center.togglePlayPauseCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent *event) {
+#pragma unused(event)
+            NowPlayingCoordinator *active = sActiveCoordinator;
+            SoundHandler *handler = active.handler;
+            if ([handler hasPlayingEligibleNowPlayingChannel])
+                [handler pauseEligibleNowPlayingChannels];
+            else
+                [handler unpauseEligibleNowPlayingChannels];
+            [active refresh];
+            return MPRemoteCommandHandlerStatusSuccess;
+        }];
+
+        // Pause must not be treated as stop: keep position and session.
+        center.stopCommand.enabled = NO;
+        center.nextTrackCommand.enabled = NO;
+        center.previousTrackCommand.enabled = NO;
+        center.seekForwardCommand.enabled = NO;
+        center.seekBackwardCommand.enabled = NO;
+        center.changePlaybackPositionCommand.enabled = NO;
+    });
+}
+
+- (void)clearNowPlayingInfo {
+    MPNowPlayingInfoCenter *infoCenter = [MPNowPlayingInfoCenter defaultCenter];
+    infoCenter.nowPlayingInfo = nil;
+    infoCenter.playbackState = MPNowPlayingPlaybackStateStopped;
+}
+
+- (void)clear {
+    // Only clear the system UI if we own the session; otherwise another
+    // game window's idle SoundHandler would wipe a paused track.
+    if (!_ownsNowPlayingSession && sActiveCoordinator != self)
+        return;
+
+    _ownsNowPlayingSession = NO;
+    if (sActiveCoordinator == self)
+        sActiveCoordinator = nil;
+    [self clearNowPlayingInfo];
+}
+
+- (void)refresh {
+    SoundHandler *handler = _handler;
+    if (!handler) {
+        [self clear];
+        return;
+    }
+
+    BOOL anyEligible = NO;
+    BOOL anyPlaying = NO;
+    BOOL anyPaused = NO;
+    NSTimeInterval duration = 0;
+    BOOL looping = NO;
+
+    for (GlkSoundChannel *chan in handler.glkchannels.allValues) {
+        if (!chan.claimsNowPlaying || chan.status == GlkSoundChannelStatusIdle)
+            continue;
+        anyEligible = YES;
+        if (chan.isPaused)
+            anyPaused = YES;
+        else
+            anyPlaying = YES;
+        if (chan.nowPlayingLooping)
+            looping = YES;
+        if (chan.nowPlayingDuration > duration)
+            duration = chan.nowPlayingDuration;
+    }
+
+    if (!anyEligible) {
+        // Only tear down system Now Playing if *this* handler had claimed it.
+        // Other SoundHandlers (other game windows) must not wipe a paused session.
+        if (_ownsNowPlayingSession)
+            [self clear];
+        return;
+    }
+
+    _ownsNowPlayingSession = YES;
+    sActiveCoordinator = self;
+
+    NSMutableDictionary *info = [NSMutableDictionary dictionary];
+
+    NSString *title = handler.glkctl.game.metadata.title;
+    if (title.length)
+        info[MPMediaItemPropertyTitle] = title;
+    else
+        info[MPMediaItemPropertyTitle] = @"Spatterlight";
+
+    info[MPMediaItemPropertyArtist] = @"Spatterlight";
+
+    NSObject *coverObj = handler.glkctl.game.metadata.cover.data;
+    if ([coverObj isKindOfClass:[NSData class]]) {
+        NSData *coverData = (NSData *)coverObj;
+        if (coverData.length) {
+            NSImage *image = [[NSImage alloc] initWithData:coverData];
+            if (image) {
+                CGSize size = image.size;
+                MPMediaItemArtwork *artwork =
+                    [[MPMediaItemArtwork alloc] initWithBoundsSize:size
+                                                    requestHandler:^NSImage *(CGSize requestSize) {
+#pragma unused(requestSize)
+                                                        return image;
+                                                    }];
+                info[MPMediaItemPropertyArtwork] = artwork;
+            }
+        }
+    }
+
+    if (!looping && duration > 0)
+        info[MPMediaItemPropertyPlaybackDuration] = @(duration);
+
+    info[MPNowPlayingInfoPropertyPlaybackRate] = anyPlaying ? @1.0 : @0.0;
+
+    MPNowPlayingInfoCenter *infoCenter = [MPNowPlayingInfoCenter defaultCenter];
+    infoCenter.nowPlayingInfo = info;
+    if (anyPlaying)
+        infoCenter.playbackState = MPNowPlayingPlaybackStatePlaying;
+    else if (anyPaused)
+        infoCenter.playbackState = MPNowPlayingPlaybackStatePaused;
+    else
+        infoCenter.playbackState = MPNowPlayingPlaybackStateStopped;
+}
+
+@end

--- a/application/Sounds/SoundHandler.h
+++ b/application/Sounds/SoundHandler.h
@@ -7,7 +7,7 @@
 
 #import <Foundation/Foundation.h>
 
-@class GlkSoundChannel, GlkController, SoundHandler, NowPlayingCoordinator;
+@class GlkSoundChannel, GlkController, SoundHandler;
 
 typedef uint32_t glui32;
 typedef int32_t glsi32;

--- a/application/Sounds/SoundHandler.h
+++ b/application/Sounds/SoundHandler.h
@@ -7,7 +7,7 @@
 
 #import <Foundation/Foundation.h>
 
-@class GlkSoundChannel, GlkController, SoundHandler;
+@class GlkSoundChannel, GlkController, SoundHandler, NowPlayingCoordinator;
 
 typedef uint32_t glui32;
 typedef int32_t glsi32;
@@ -72,6 +72,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)restartAll;
 - (void)stopAllAndCleanUp;
+
+- (void)nowPlayingStateDidChange;
+- (void)pauseEligibleNowPlayingChannels;
+- (void)unpauseEligibleNowPlayingChannels;
+- (BOOL)hasPlayingEligibleNowPlayingChannel;
 
 - (int)handleNewSoundChannel:(glui32)volume;
 - (void)handleDeleteChannel:(int)channel;

--- a/application/Sounds/SoundHandler.m
+++ b/application/Sounds/SoundHandler.m
@@ -11,6 +11,7 @@
 
 #import "GlkSoundChannel.h"
 #import "MIDIChannel.h"
+#import "NowPlayingCoordinator.h"
 #import "GlkController.h"
 #import "GlkController+InterpreterGlue.h"
 #import "GlkEvent.h"
@@ -212,6 +213,7 @@
  * device ahead of the first real tone, held strongly while it plays. See
  * primeBeepAudio. */
 @property (strong, nullable) NSSound *beepPrimeSound;
+@property (strong, nullable) NowPlayingCoordinator *nowPlayingCoordinator;
 @end
 
 @implementation SoundHandler
@@ -224,6 +226,7 @@
         _glkchannels = [NSMutableDictionary new];
         _files = [NSMutableDictionary new];
         _lastsoundresno = -1;
+        _nowPlayingCoordinator = [[NowPlayingCoordinator alloc] initWithSoundHandler:self];
     }
     return self;
 }
@@ -245,6 +248,7 @@
             }
         _glkchannels = [decoder decodeObjectOfClasses:[NSSet setWithObjects:[NSMutableDictionary class], [NSNumber class], [GlkSoundChannel class], nil] forKey:@"gchannels"];
         _lastsoundresno = [decoder decodeIntForKey:@"lastsoundresno"];
+        _nowPlayingCoordinator = [[NowPlayingCoordinator alloc] initWithSoundHandler:self];
     }
     return self;
 }
@@ -367,7 +371,9 @@
 
 - (void)handleDeleteChannel:(int)channel {
     if (_glkchannels[@(channel)]) {
+        [_glkchannels[@(channel)] stop];
         _glkchannels[@(channel)] = nil;
+        [self nowPlayingStateDidChange];
     }
 }
 
@@ -430,14 +436,46 @@
         chan.handler = self;
         [chan restartInternal];
     }
+    [self nowPlayingStateDidChange];
 }
 
 - (void)stopAllAndCleanUp {
-    if (!_glkchannels.count)
+    if (!_glkchannels.count) {
+        [_nowPlayingCoordinator clear];
         return;
+    }
     for (GlkSoundChannel* chan in _glkchannels.allValues) {
         [chan stop];
     }
+    [_nowPlayingCoordinator clear];
+}
+
+#pragma mark Now Playing
+
+- (void)nowPlayingStateDidChange {
+    [_nowPlayingCoordinator refresh];
+}
+
+- (void)pauseEligibleNowPlayingChannels {
+    for (GlkSoundChannel *chan in _glkchannels.allValues) {
+        if (chan.claimsNowPlaying && chan.status != GlkSoundChannelStatusIdle && !chan.isPaused)
+            [chan pause];
+    }
+}
+
+- (void)unpauseEligibleNowPlayingChannels {
+    for (GlkSoundChannel *chan in _glkchannels.allValues) {
+        if (chan.claimsNowPlaying && chan.status != GlkSoundChannelStatusIdle && chan.isPaused)
+            [chan unpause];
+    }
+}
+
+- (BOOL)hasPlayingEligibleNowPlayingChannel {
+    for (GlkSoundChannel *chan in _glkchannels.allValues) {
+        if (chan.claimsNowPlaying && chan.status != GlkSoundChannelStatusIdle && !chan.isPaused)
+            return YES;
+    }
+    return NO;
 }
 
 #pragma mark Called from GlkSoundChannel

--- a/application/Sounds/SoundHandler.m
+++ b/application/Sounds/SoundHandler.m
@@ -213,7 +213,6 @@
  * device ahead of the first real tone, held strongly while it plays. See
  * primeBeepAudio. */
 @property (strong, nullable) NSSound *beepPrimeSound;
-@property (strong, nullable) NowPlayingCoordinator *nowPlayingCoordinator;
 @end
 
 @implementation SoundHandler
@@ -226,7 +225,6 @@
         _glkchannels = [NSMutableDictionary new];
         _files = [NSMutableDictionary new];
         _lastsoundresno = -1;
-        _nowPlayingCoordinator = [[NowPlayingCoordinator alloc] initWithSoundHandler:self];
     }
     return self;
 }
@@ -248,7 +246,6 @@
             }
         _glkchannels = [decoder decodeObjectOfClasses:[NSSet setWithObjects:[NSMutableDictionary class], [NSNumber class], [GlkSoundChannel class], nil] forKey:@"gchannels"];
         _lastsoundresno = [decoder decodeIntForKey:@"lastsoundresno"];
-        _nowPlayingCoordinator = [[NowPlayingCoordinator alloc] initWithSoundHandler:self];
     }
     return self;
 }
@@ -373,7 +370,6 @@
     if (_glkchannels[@(channel)]) {
         [_glkchannels[@(channel)] stop];
         _glkchannels[@(channel)] = nil;
-        [self nowPlayingStateDidChange];
     }
 }
 
@@ -436,43 +432,38 @@
         chan.handler = self;
         [chan restartInternal];
     }
-    [self nowPlayingStateDidChange];
 }
 
 - (void)stopAllAndCleanUp {
-    if (!_glkchannels.count) {
-        [_nowPlayingCoordinator clear];
-        return;
-    }
     for (GlkSoundChannel* chan in _glkchannels.allValues) {
         [chan stop];
     }
-    [_nowPlayingCoordinator clear];
+    [[NowPlayingCoordinator shared] clearForHandler:self];
 }
 
 #pragma mark Now Playing
 
 - (void)nowPlayingStateDidChange {
-    [_nowPlayingCoordinator refresh];
+    [[NowPlayingCoordinator shared] refreshForHandler:self];
 }
 
 - (void)pauseEligibleNowPlayingChannels {
     for (GlkSoundChannel *chan in _glkchannels.allValues) {
-        if (chan.claimsNowPlaying && chan.status != GlkSoundChannelStatusIdle && !chan.isPaused)
+        if (chan.claimsNowPlaying && !chan.isPaused)
             [chan pause];
     }
 }
 
 - (void)unpauseEligibleNowPlayingChannels {
     for (GlkSoundChannel *chan in _glkchannels.allValues) {
-        if (chan.claimsNowPlaying && chan.status != GlkSoundChannelStatusIdle && chan.isPaused)
+        if (chan.claimsNowPlaying && chan.isPaused)
             [chan unpause];
     }
 }
 
 - (BOOL)hasPlayingEligibleNowPlayingChannel {
     for (GlkSoundChannel *chan in _glkchannels.allValues) {
-        if (chan.claimsNowPlaying && chan.status != GlkSoundChannelStatusIdle && !chan.isPaused)
+        if (chan.claimsNowPlaying && !chan.isPaused)
             return YES;
     }
     return NO;


### PR DESCRIPTION
This allows users to quickly see that Spatterlight is the one playing the music, and to easily pause/unpause it.

(We register as music when the sound duration is more than 5s, or is looping.)