### PR TITLE
Don't attempt to load a 0-sized image

### DIFF
--- a/terps/scarier/os_glk.cpp
+++ b/terps/scarier/os_glk.cpp
@@ -2643,6 +2643,9 @@ gsc_refresh_windows (void)
 void
 os_show_graphic (const scr_char *filepath, scr_int offset, scr_int length)
 {
+  if (length <= 0 || gsc_main_window == NULL)
+    return;
+
   glui32 id = garglk_add_resource_from_file(giblorb_ID_Pict, gamefile, offset, length);
   if (id != 0)
     gsc_draw_inline_graphic(id);


### PR DESCRIPTION
This mirrors Spatterlight's behavior below.