### PR TITLE
Replace unsafe usage of strncpy() and strncat() with snprintf()

### DIFF
--- a/terps/scarier/scexpr.cpp
+++ b/terps/scarier/scexpr.cpp
@@ -1125,8 +1125,13 @@ expr_eval_action (scr_int token)
          * Resize text1 to be long enough for both, and concatenate, then
          * free text2, and push back the concatenation.
          */
-        text1 = (decltype(text1)) scr_realloc (text1, strlen (text1) + strlen (text2) + 1);
-        strncat (text1, text2, strlen (text2));
+        {
+          size_t used = strlen (text1);
+          size_t size = used + strlen (text2) + 1;
+
+          text1 = (decltype(text1)) scr_realloc (text1, size);
+          snprintf (text1 + used, size - used, "%s", text2);
+        }
         scr_free (text2);
         expr_eval_push_alloced_string (text1);
         break;

--- a/terps/scarier/scresour.cpp
+++ b/terps/scarier/scresour.cpp
@@ -24,6 +24,7 @@
  */
 
 #include <assert.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -120,7 +121,7 @@ res_handle_resource (scr_gameref_t game,
 {
   const scr_prop_setref_t bundle = gs_get_bundle (game);
   scr_vartype_t vt_key[2], *vt_full;
-  scr_int partial_length, resource_start_offset;
+  scr_int partial_length, format_size, resource_start_offset;
   scr_bool embedded;
   scr_char *format;
   assert (gs_is_game_valid (game));
@@ -152,11 +153,13 @@ res_handle_resource (scr_gameref_t game,
 
   /*
    * Allocate a format for use with properties calls, five characters longer
-   * than the partial passed in.  Build a key one element larger than the
-   * partial supplied, and copy over all supplied elements.
+   * than the partial passed in: three for the leading "X<-", one for the
+   * trailing "s", and one for the terminator.  Build a key one element larger
+   * than the partial supplied, and copy over all supplied elements.
    */
   partial_length = strlen (partial_format);
-  format = (decltype(format)) scr_malloc (partial_length + 5);
+  format_size = partial_length + 5;
+  format = (decltype(format)) scr_malloc (format_size);
 
   vt_full = (decltype(vt_full)) scr_malloc ((partial_length + 1) * sizeof (vt_partial[0]));
   memcpy (vt_full, vt_partial, partial_length * sizeof (vt_partial[0]));
@@ -169,9 +172,7 @@ res_handle_resource (scr_gameref_t game,
 
       /* Get soundfile property from the node supplied. */
       vt_full[partial_length].string = "SoundFile";
-      strncpy (format, "S<-", partial_length + 5);
-      strncat (format, partial_format, partial_length);
-      strncat (format, "s", 1);
+      snprintf (format, format_size, "S<-%ss", partial_format);
       soundfile = prop_get_string (bundle, format, vt_full);
 
       /* If a sound is defined, handle it. */
@@ -181,16 +182,12 @@ res_handle_resource (scr_gameref_t game,
             {
               /* Retrieve offset and length. */
               vt_full[partial_length].string = "SoundOffset";
-              strncpy (format, "I<-", partial_length + 5);
-              strncat (format, partial_format, partial_length);
-              strncat (format, "s", 1);
+              snprintf (format, format_size, "I<-%ss", partial_format);
               soundoffset = prop_get_integer (bundle, format, vt_full)
                             + resource_start_offset;
 
               vt_full[partial_length].string = "SoundLen";
-              strncpy (format, "I<-", partial_length + 5);
-              strncat (format, partial_format, partial_length);
-              strncat (format, "s", 1);
+              snprintf (format, format_size, "I<-%ss", partial_format);
               soundlen = prop_get_integer (bundle, format, vt_full);
             }
           else
@@ -225,9 +222,7 @@ res_handle_resource (scr_gameref_t game,
 
       /* Get graphicfile property from the node supplied. */
       vt_full[partial_length].string = "GraphicFile";
-      strncpy (format, "S<-", partial_length + 5);
-      strncat (format, partial_format, partial_length);
-      strncat (format, "s", 1);
+      snprintf (format, format_size, "S<-%ss", partial_format);
       graphicfile = prop_get_string (bundle, format, vt_full);
 
       /* If a graphic is defined, handle it. */
@@ -237,16 +232,12 @@ res_handle_resource (scr_gameref_t game,
             {
               /* Retrieve offset and length. */
               vt_full[partial_length].string = "GraphicOffset";
-              strncpy (format, "I<-", partial_length + 5);
-              strncat (format, partial_format, partial_length);
-              strncat (format, "s", 1);
+              snprintf (format, format_size, "I<-%ss", partial_format);
               graphicoffset = prop_get_integer (bundle, format, vt_full)
                               + resource_start_offset;
 
               vt_full[partial_length].string = "GraphicLen";
-              strncpy (format, "I<-", partial_length + 5);
-              strncat (format, partial_format, partial_length);
-              strncat (format, "s", 1);
+              snprintf (format, format_size, "I<-%ss", partial_format);
               graphiclen = prop_get_integer (bundle, format, vt_full);
             }
           else

--- a/terps/scarier/sctafpar.cpp
+++ b/terps/scarier/sctafpar.cpp
@@ -1180,8 +1180,10 @@ parse_read_multiline (void)
   line = parse_get_taf_string ();
   while (memcmp (line, separator, SEPARATOR_SIZE) != 0)
     {
-      scr_char *grown = (scr_char *) scr_realloc (multiline.get (),
-                              strlen (multiline.get ()) + strlen (line) + 2);
+      /* Room for what is there, a newline, this line, and the terminator. */
+      size_t used = strlen (multiline.get ());
+      size_t size = used + strlen (line) + 2;
+      scr_char *grown = (scr_char *) scr_realloc (multiline.get (), size);
       /*
        * scr_realloc has freed the old block and returned the grown one; give
        * up ownership of the (now invalid) old pointer without freeing it, and
@@ -1190,8 +1192,7 @@ parse_read_multiline (void)
        */
       multiline.release ();
       multiline.reset (grown);
-      strncat (multiline.get (), "\n", 1);
-      strncat (multiline.get (), line, strlen (line));
+      snprintf (grown + used, size - used, "\n%s", line);
       line = parse_get_taf_string ();
     }
 
@@ -1839,10 +1840,18 @@ parse_write_restrmask (void)
       scr_int index_;
       size_t restrmask_size = parse_checked_multiply (restriction_count, 2);
 
+      /* "#" then "A#" per additional restriction: 2 * count bytes with the
+         terminator, which is exactly what was allocated above. */
+      size_t used = 1;
+
       restrmask = (decltype(restrmask)) scr_malloc (restrmask_size);
-      strncpy (restrmask, "#", restrmask_size);
+      restrmask[0] = '#';
+      restrmask[1] = '\0';
       for (index_ = 1; index_ < restriction_count; index_++)
-        strncat (restrmask, "A#", 2);
+        {
+          snprintf (restrmask + used, restrmask_size - used, "A#");
+          used += 2;
+        }
 
       parse_put_keyed_string ("RestrMask", restrmask);
       prop_adopt (parse_bundle, restrmask);

--- a/terps/scarier/scvars.cpp
+++ b/terps/scarier/scvars.cpp
@@ -410,13 +410,16 @@ var_append_temp (scr_var_setref_t vars, const scr_char *string)
     }
   else
     {
-      /* Append string to existing temporary. */
+      /* Append string to existing temporary; `noted` is already the length to
+         append at, and is reused below to case the first new character. */
       new_sentence = (vars->temporary[0] == NUL);
       noted = strlen (vars->temporary);
-      vars->temporary = (decltype(vars->temporary)) scr_realloc (vars->temporary,
-                                    strlen (vars->temporary) +
-                                    strlen (string) + 1);
-      strncat (vars->temporary, string, strlen (string));
+      {
+        size_t size = (size_t) noted + strlen (string) + 1;
+
+        vars->temporary = (decltype(vars->temporary)) scr_realloc (vars->temporary, size);
+        snprintf (vars->temporary + noted, size - (size_t) noted, "%s", string);
+      }
     }
 
   if (new_sentence)
@@ -941,11 +944,13 @@ var_get_system (scr_var_setref_t vars,
           vt_key[2].string = "Short";
           objname = prop_get_string (bundle, "S<-sis", vt_key);
 
-          vars->temporary = (decltype(vars->temporary)) scr_realloc (vars->temporary,
-                                        strlen (vars->temporary)
-                                        + strlen (objname) + 2);
-          strncat (vars->temporary, " ", 1);
-          strncat (vars->temporary, objname, strlen (objname));
+          {
+            size_t used = strlen (vars->temporary);
+            size_t size = used + strlen (objname) + 2;
+
+            vars->temporary = (decltype(vars->temporary)) scr_realloc (vars->temporary, size);
+            snprintf (vars->temporary + used, size - used, " %s", objname);
+          }
 
           return var_return_string (vars->temporary, type, vt_rvalue);
         }
@@ -1343,46 +1348,60 @@ var_get_system (scr_var_setref_t vars,
           /* Return object name prefixed with "the"... */
           scr_vartype_t vt_key[3];
           const scr_char *prefix, *normalized, *objname;
+          size_t size, used = 0;
 
           vt_key[0].string = "Objects";
           vt_key[1].integer = vars->referenced_object;
           vt_key[2].string = "Prefix";
           prefix = prop_get_string (bundle, "S<-sis", vt_key);
 
-          vars->temporary = (decltype(vars->temporary)) scr_realloc (vars->temporary, strlen (prefix) + 5);
+          /* "the" plus the de-articled prefix, a separating space, and the
+             terminator; never more than the prefix length plus five. */
+          size = strlen (prefix) + 5;
+          vars->temporary = (decltype(vars->temporary)) scr_realloc (vars->temporary, size);
           vars->temporary[0] = '\0';
 
           normalized = prefix;
           if (scr_compare_word (prefix, "a", 1))
             {
-              strncat (vars->temporary, "the", 3);
+              snprintf (vars->temporary + used, size - used, "the");
+              used = strlen (vars->temporary);
               normalized = prefix + 1;
             }
           else if (scr_compare_word (prefix, "an", 2))
             {
-              strncat (vars->temporary, "the", 3);
+              snprintf (vars->temporary + used, size - used, "the");
+              used = strlen (vars->temporary);
               normalized = prefix + 2;
             }
           else if (scr_compare_word (prefix, "the", 3))
             {
-              strncat (vars->temporary, "the", 3);
+              snprintf (vars->temporary + used, size - used, "the");
+              used = strlen (vars->temporary);
               normalized = prefix + 3;
             }
           else if (scr_compare_word (prefix, "some", 4))
             {
-              strncat (vars->temporary, "the", 3);
+              snprintf (vars->temporary + used, size - used, "the");
+              used = strlen (vars->temporary);
               normalized = prefix + 4;
             }
           else if (scr_strempty (prefix))
-            strncat (vars->temporary, "the ", 4);
+            {
+              snprintf (vars->temporary + used, size - used, "the ");
+              used = strlen (vars->temporary);
+            }
 
           if (!scr_strempty (normalized))
             {
-              strncat (vars->temporary, normalized, strlen (normalized));
-              strncat (vars->temporary, " ", 1);
+              snprintf (vars->temporary + used, size - used, "%s ", normalized);
+              used = strlen (vars->temporary);
             }
           else if (normalized > prefix)
-            strncat (vars->temporary, " ", 1);
+            {
+              snprintf (vars->temporary + used, size - used, " ");
+              used = strlen (vars->temporary);
+            }
 
           vt_key[2].string = "Short";
           objname = prop_get_string (bundle, "S<-sis", vt_key);
@@ -1395,10 +1414,9 @@ var_get_system (scr_var_setref_t vars,
           else if (scr_compare_word (objname, "some", 4))
             objname += 4;
 
-          vars->temporary = (decltype(vars->temporary)) scr_realloc (vars->temporary,
-                                        strlen (vars->temporary)
-                                        + strlen (objname) + 1);
-          strncat (vars->temporary, objname, strlen (objname));
+          size = used + strlen (objname) + 1;
+          vars->temporary = (decltype(vars->temporary)) scr_realloc (vars->temporary, size);
+          snprintf (vars->temporary + used, size - used, "%s", objname);
 
           return var_return_string (vars->temporary, type, vt_rvalue);
         }


### PR DESCRIPTION
strncpy() and strncat() will only write as many bytes as you tell them, so are "safe" alternatives (well, not strncpy() since it has relatively stupid behavior now that V7 unix is obsolete); but they are only safe if they know how many bytes they're supposed to write, i.e. the target size. All these calls take their size from the _source_, not the target, and as such, are no better than plain old strcpy() and strcat().

Since this code requires at least C++11, that means it incorporates C99 or later, which provides snprintf(). This replaces all potentially unsafe calls to strncpy() and strncat() with snprintf().

---

From what I can tell there are no potential overflows, so the code is safe as-is. However, the use of strncpy() and strncat() implies an eye toward buffer overflow safety, but does not actually provide any safety as written. If switching to snprintf() is not acceptable, I would very strongly recommend switching back to strcat() and strcpy() which are at least plainly honest in their potential lack of safety() and convey that more clearly than the incorrectly-sized strncpy()/strncat().