### PR TITLE
Fix harness runner

### DIFF
--- a/terps/scarier/Makefile.headless
+++ b/terps/scarier/Makefile.headless
@@ -156,8 +156,8 @@ V4_GAMES_DIR ?= test/adrift4/games
 
 # Default regression suite: Scarier in isolation.  No FrankenDrift / dotnet.
 # Covers unit harnesses, capacity, gamescheck, a5runtest, v4 walkthroughs,
-# and golden-backed a5 walkthroughs (rows without an *_expected.txt are
-# SKIPPED -- those need `test-fd`).
+# a5maptest, scprojregress, and golden-backed a5 walkthroughs (rows without an
+# *_expected.txt are SKIPPED -- those need `test-fd`).
 test: $(BIN) $(TAF) $(PREC_BIN) $(PREC_TAF) $(BADP_BIN) $(BADP_TAF) $(CORRUPT_BIN) $(QUIT_BIN) $(A5PARSE_BIN) $(A5SEXPR_BIN) $(A5DIS_BIN) $(A5WALK_BIN) $(A5OBJ_BIN) $(A5SAVE_BIN)
 	./$(BIN) $(TAF)
 	./$(PREC_BIN) $(PREC_TAF)
@@ -176,6 +176,8 @@ test: $(BIN) $(TAF) $(PREC_BIN) $(PREC_TAF) $(BADP_BIN) $(BADP_TAF) $(CORRUPT_BI
 	@$(MAKE) -f Makefile.headless gamescheck
 	@$(MAKE) -f Makefile.headless a5runtest
 	@$(MAKE) -f Makefile.headless v4walkthroughs
+	@$(MAKE) -f Makefile.headless a5maptest
+	@$(MAKE) -f Makefile.headless scprojregress
 	@$(MAKE) -f Makefile.headless a5walkthroughs-golden
 
 # Opt-in: ADRIFT 5 walkthrough corpus vs FrankenDrift (needs FD.Headless +
@@ -267,7 +269,8 @@ a5walkthroughs-golden: $(A5RUN_BIN)
 	@test/adrift5/harness/run_a5_walkthroughs.sh --golden-only
 
 # Deterministic projectile-combat regression (ADRIFT 4 Battle System).  SKIPs
-# when the five battle-game .taf files are absent; no FrankenDrift.
+# when the five battle-game .taf files are absent; no FrankenDrift.  Part of
+# default `test`.
 scprojregress:
 	@sh test/adrift4/harness/scproj_regress.sh
 
@@ -290,6 +293,7 @@ a5probetafs:
 # stress test (adrift5/probes/map.taf) and compares PPM hashes against the
 # committed manifest.  Self-blessed (the real Runner map is GUI-only);
 # re-bless intentional rendering changes with test/adrift5/harness/run_a5_maptest.sh -b.
+# Part of default `test` (no FrankenDrift).
 a5maptest: $(A5MAP_BIN)
 	test/adrift5/harness/run_a5_maptest.sh
 

--- a/terps/scarier/Makefile.headless
+++ b/terps/scarier/Makefile.headless
@@ -1,14 +1,13 @@
-# Headless build + regression test for the Scarier Battle System port.
+# Headless build + regression test for the Scarier ADRIFT engines.
 #
-# Builds a small console harness (test/adrift4/harness/battle_test.cpp) that links the Scarier
-# interpreter sources against the bundled sx* os-layer stubs (no Glk, links the
-# system zlib) and runs it against the synthetic, fully deterministic game
-# test/adrift4/harness/battle_test.taf.  The harness checks the combat math through the public
-# battle API and exits non-zero on any mismatch.
+# Builds small console harnesses that link the Scarier interpreter sources
+# against the bundled sx* os-layer stubs (no Glk, links the system zlib) and
+# runs them against synthetic / golden-backed games.
 #
 # Usage:
-#   make -f Makefile.headless test     # build and run the battle test
-#   make -f Makefile.headless taf      # regenerate test/adrift4/harness/battle_test.taf
+#   make -f Makefile.headless test      # Scarier in isolation (default; no FrankenDrift)
+#   make -f Makefile.headless test-fd   # opt-in: diff a5 walkthroughs against FrankenDrift
+#   make -f Makefile.headless taf       # regenerate test/adrift4/harness/battle_test.taf
 #   make -f Makefile.headless clean
 #
 # test/adrift4/harness/battle_test.taf is a hand-authored ADRIFT 4.0 file (see
@@ -138,8 +137,7 @@ WHERE_TAF  := test/adrift4/harness/where_refusal.taf \
               test/adrift4/harness/where_refusal_3p.taf
 WHERE_PROBES := where_refusal where_refusal_1p where_refusal_3p
 
-.PHONY: test sanitize taf clean capacitytest capacitybless wheretest wherebless scmap a5dump a5model a5text a5run a5map a5parsetest a5runtest a5walkthroughs a5probetafs a5maptest a5distest a5walktest a5objtest a5savetest a5sexprtest v4walkthroughs gamescheck gamesfetch
-
+.PHONY: test test-fd sanitize taf clean capacitytest capacitybless wheretest wherebless scmap a5dump a5model a5text a5run a5map a5parsetest a5runtest a5walkthroughs a5walkthroughs-golden a5probetafs a5maptest a5distest a5walktest a5objtest a5savetest a5sexprtest v4walkthroughs scprojregress gamescheck gamesfetch vendorcheck
 # ADRIFT 5 game files live in an untracked (gitignored) folder under test/ so the
 # harnesses can find them by a stable in-repo path; the games themselves are
 # copyrighted and not committed.  Override A5_GAMES_DIR / A5_BULLETS to relocate.
@@ -156,6 +154,10 @@ A5_BULLETS ?= $(A5_GAMES_DIR)/SixSilverBullets.blorb
 # skips entirely when no corpus is present.
 V4_GAMES_DIR ?= test/adrift4/games
 
+# Default regression suite: Scarier in isolation.  No FrankenDrift / dotnet.
+# Covers unit harnesses, capacity, gamescheck, a5runtest, v4 walkthroughs,
+# and golden-backed a5 walkthroughs (rows without an *_expected.txt are
+# SKIPPED -- those need `test-fd`).
 test: $(BIN) $(TAF) $(PREC_BIN) $(PREC_TAF) $(BADP_BIN) $(BADP_TAF) $(CORRUPT_BIN) $(QUIT_BIN) $(A5PARSE_BIN) $(A5SEXPR_BIN) $(A5DIS_BIN) $(A5WALK_BIN) $(A5OBJ_BIN) $(A5SAVE_BIN)
 	./$(BIN) $(TAF)
 	./$(PREC_BIN) $(PREC_TAF)
@@ -174,6 +176,12 @@ test: $(BIN) $(TAF) $(PREC_BIN) $(PREC_TAF) $(BADP_BIN) $(BADP_TAF) $(CORRUPT_BI
 	@$(MAKE) -f Makefile.headless gamescheck
 	@$(MAKE) -f Makefile.headless a5runtest
 	@$(MAKE) -f Makefile.headless v4walkthroughs
+	@$(MAKE) -f Makefile.headless a5walkthroughs-golden
+
+# Opt-in: ADRIFT 5 walkthrough corpus vs FrankenDrift (needs FD.Headless +
+# dotnet).  Alias of a5walkthroughs.
+test-fd:
+	@$(MAKE) -f Makefile.headless a5walkthroughs
 
 # Gargoyle builds Scarier from a straight copy of this directory, so the shared
 # files it needs from outside it are vendored in common_utils/ (see the README
@@ -242,16 +250,26 @@ a5runtest: $(A5RUN_BIN)
 	  echo "a5runtest: SKIP (game file not found: $(A5_BULLETS))"; \
 	fi
 
-# Real-game walkthrough corpus: replays published walkthroughs for the games in
-# $(A5_GAMES_DIR) through BOTH a5run_dump and FrankenDrift (test/adrift5/harness/a5_groundtruth.sh)
-# and checks each transcript's divergence against its recorded baseline (see
-# test/adrift5/notes/A5_WALKTHROUGH_FINDINGS.md).  Per-game SKIP when the (uncommittable) game
-# file is absent; needs FrankenDrift.Headless built for the differential games
-# (the golden-backed games, e.g. Achtung Panzer, need only a5run_dump).
-# Not part of `test` (external data + dotnet).  Fails if any game regresses
-# past its baseline hunk budget.
+# Opt-in FrankenDrift differential for the ADRIFT 5 walkthrough corpus: replays
+# published walkthroughs through BOTH a5run_dump and FrankenDrift
+# (test/adrift5/harness/a5_groundtruth.sh) and checks each transcript's
+# divergence against its recorded baseline (see
+# test/adrift5/notes/A5_WALKTHROUGH_FINDINGS.md).  Per-game SKIP when the
+# (uncommittable) game file is absent; needs FrankenDrift.Headless built.
+# Not part of `test` -- run via `make -f Makefile.headless test-fd`.  Fails if
+# any game regresses past its baseline hunk budget.
 a5walkthroughs: $(A5RUN_BIN)
 	@test/adrift5/harness/run_a5_walkthroughs.sh
+
+# Scarier-only a5 walkthroughs: strict-diff committed *_expected.txt goldens,
+# SKIP rows without a golden, no FrankenDrift/dotnet.  Part of default `test`.
+a5walkthroughs-golden: $(A5RUN_BIN)
+	@test/adrift5/harness/run_a5_walkthroughs.sh --golden-only
+
+# Deterministic projectile-combat regression (ADRIFT 4 Battle System).  SKIPs
+# when the five battle-game .taf files are absent; no FrankenDrift.
+scprojregress:
+	@sh test/adrift4/harness/scproj_regress.sh
 
 # Synthetic ADRIFT 5 conformance probes (the Probe* rows of the walkthrough
 # suite), imported from the adrift-5-rs test suite.  The committed
@@ -275,9 +293,9 @@ a5probetafs:
 a5maptest: $(A5MAP_BIN)
 	test/adrift5/harness/run_a5_maptest.sh
 
-# ASan/UBSan sweep of every self-contained, no-external-data harness that `test`
-# runs (the a5runtest game-file replay is excluded: it needs uncommittable game
-# data -- run it under sanitizers by hand with
+# ASan/UBSan sweep of every self-contained, no-external-data harness that the
+# unit portion of `test` runs (the a5runtest game-file replay is excluded: it
+# needs uncommittable game data -- run it under sanitizers by hand with
 #   make -f Makefile.headless a5runtest CXXFLAGS="$(CXXFLAGS) $(SAN_FLAGS)").
 # Each harness is rebuilt from source into a *_san binary (so there is no
 # timestamp/flag-staleness footgun) and run immediately; a sanitizer abort or a

--- a/terps/scarier/test/GAMES.md
+++ b/terps/scarier/test/GAMES.md
@@ -33,7 +33,8 @@ can never quietly replace a corpus file. Existing files are never overwritten.
 Override the corpus locations with `V4_GAMES_DIR` / `A5_GAMES_DIR` and the cache
 with `SCARIER_GAMES_CACHE`.
 
-`gamescheck` runs as part of `make -f Makefile.headless test`. It fails only on a
+`gamescheck` runs as part of `make -f Makefile.headless test` (the default
+isolation suite; no FrankenDrift). It fails only on a
 **mismatch** — a file that is present but is not the recorded bytes. Missing files
 are not an error, because an empty corpus is a legitimate state. Bypass it with
 `SCARIER_SKIP_GAMESCHECK=1`.

--- a/terps/scarier/test/adrift4/README.md
+++ b/terps/scarier/test/adrift4/README.md
@@ -64,8 +64,9 @@ sh scproj_regress.sh
 ```
 
 `run_v4_walkthroughs.sh` is wired into `make -f Makefile.headless test` via the
-`v4walkthroughs` target, which skips the whole thing when no `games/` corpus
-exists on the machine. Rows whose `.taf` is missing SKIP rather than fail.
+`v4walkthroughs` target (Scarier in isolation; no FrankenDrift), which skips the
+whole thing when no `games/` corpus exists on the machine. Rows whose `.taf` is
+missing SKIP rather than fail.
 
 ## Elsewhere
 

--- a/terps/scarier/test/adrift5/harness/run.sh
+++ b/terps/scarier/test/adrift5/harness/run.sh
@@ -5,9 +5,10 @@
 #   out.txt (defaults to the current dir); pair with route.py / annotate.py,
 #   which read map.tsv / out.txt from the same dir.  Blind-walkthrough
 #   derivation tooling — see TODO_a5_walkthrough_wiring.md (⭐ TheFortressOfFear).
-cd /Users/administrator/spatterlight/terps/scarier
+HERE=$(cd "$(dirname "$0")/../../.." && pwd)
 S=${A5WORK:-$(pwd)}
 N=${1:-12}
+cd "$HERE"
 ./test/adrift5/harness/a5run_dump test/adrift5/games/TheFortressOfFear.blorb "$S/wt.txt" > "$S/out.txt" 2>&1
 # print from the Nth-from-last prompt line
 total=$(grep -c '^> ' "$S/out.txt")

--- a/terps/scarier/test/adrift5/harness/run_a5_walkthroughs.sh
+++ b/terps/scarier/test/adrift5/harness/run_a5_walkthroughs.sh
@@ -30,8 +30,12 @@
 # Exit status: non-zero iff any game regressed in either mode.
 #
 # Usage:
-#   test/adrift5/harness/run_a5_walkthroughs.sh [-v] [-j N] [substring]
+#   test/adrift5/harness/run_a5_walkthroughs.sh [-v] [-g] [-j N] [substring]
 #     -v          dump each diff to /tmp/a5wt/<Game>{,.xoshiro}.diff
+#     -g|--golden-only
+#                 Scarier-only: strict-diff committed *_expected.txt goldens,
+#                 skip rows without a golden, skip the xoshiro/FD pass.
+#                 No FrankenDrift / dotnet required.
 #     -j N        run N games concurrently (default: hw.ncpu; 1 = serial)
 #     substring   only run scripts whose name contains <substring>
 #
@@ -40,9 +44,11 @@
 #      $FD_ROOT: the runner probes for the dll at startup and refuses to run
 #      without it, because a missing ground truth would otherwise report a clean
 #      MATCH for every game (see the guard below the run_one definition).
+#      Exempt under GOLDEN_ONLY=1 / --golden-only (Scarier goldens only, no FD).
 #      XOSHIRO=0 skips the (dotnet-heavy) xoshiro pass.
-#      SAVERESTORE=0 skips the per-game save/restore self-check (a5run_dump
-#      only; on by default, adds one extra replay per game).
+#      GOLDEN_ONLY=1 same as --golden-only.  SAVERESTORE=0 skips the per-game
+#      save/restore self-check (a5run_dump only; on by default, adds one extra
+#      replay per game).
 
 set -u
 HERE=$(cd "$(dirname "$0")/../../.." && pwd)
@@ -52,11 +58,13 @@ A5RUN="$HERE/test/adrift5/harness/a5run_dump"
 
 VERBOSE=0
 BLESS=0
+GOLDEN_ONLY="${GOLDEN_ONLY:-0}"
 JOBS="${A5WT_JOBS:-$(sysctl -n hw.ncpu 2>/dev/null || echo 4)}"
 while :; do
     case "${1:-}" in
         -v) VERBOSE=1; shift ;;
         -b|--bless) BLESS=1; shift ;;   # (re)write each matched game's golden
+        -g|--golden-only) GOLDEN_ONLY=1; shift ;;
         -j) JOBS="$2"; shift 2 ;;
         *) break ;;
     esac
@@ -64,6 +72,8 @@ done
 [ "$JOBS" -ge 1 ] 2>/dev/null || JOBS=1
 FILTER="${1:-}"
 [ "$VERBOSE" = 1 ] && mkdir -p /tmp/a5wt
+# Golden-only never needs FrankenDrift: force-skip the xoshiro pass.
+[ "$GOLDEN_ONLY" = 1 ] && XOSHIRO=0
 
 # script-basename | game file | baseline hunk budget (current known divergence;
 # 0 = must stay clean).  Raise/lower a budget when you re-bless after a fix.
@@ -1653,6 +1663,16 @@ run_one() {  # $1=idx $2=name $3=game $4=vbudget $5=xbudget
         return
     fi
 
+    # --- vanilla -------------------------------------------------------------
+    # Fast strict golden diff when a golden exists (vanilla transcript, no dotnet).
+    golden="$HERE/test/adrift5/goldens/${name}_expected.txt"
+    # Golden-only mode: no FrankenDrift.  Rows without a committed expected
+    # transcript cannot be checked, so SKIP them rather than calling GT.
+    if [ "$GOLDEN_ONLY" = 1 ] && [ "$BLESS" != 1 ] && [ ! -f "$golden" ]; then
+        printf "%-24s %-9s (no expected transcript)\n" "$name" "SKIP" > "$row"
+        return
+    fi
+
     # ONE Scarier replay per game, shared by the golden compare/bless AND both
     # RNG-mode ground-truth diffs (via SCARIER_TXT): Scarier's transcript is
     # RNG-mode-independent -- only FrankenDrift's generator changes between the
@@ -1660,9 +1680,6 @@ run_one() {  # $1=idx $2=name $3=game $4=vbudget $5=xbudget
     stxt="$WORKDIR/$idx.scarier"
     "$A5RUN" "$gf" "$script" 2>/dev/null > "$stxt" || true
 
-    # --- vanilla -------------------------------------------------------------
-    # Fast strict golden diff when a golden exists (vanilla transcript, no dotnet).
-    golden="$HERE/test/adrift5/goldens/${name}_expected.txt"
     if [ "$BLESS" = 1 ]; then
         # (Re)write the golden through the SAME normalisation the comparison uses,
         # so blessing is canonical and never trips the trailing-newline artifact.
@@ -1693,6 +1710,7 @@ run_one() {  # $1=idx $2=name $3=game $4=vbudget $5=xbudget
         want=$(cat "$golden")
         if [ "$got" = "$want" ]; then hv=0; else hv=999; fi
     else
+        # Differential vs FrankenDrift -- unreachable in GOLDEN_ONLY (skipped above).
         vout=$(SCARIER_TXT="$stxt" "$GT" "$gf" "$script" 2>/dev/null)
         [ "$VERBOSE" = 1 ] && printf '%s\n' "$vout" > "/tmp/a5wt/${name}.diff"
         gt_ran "$vout" || vgtfail=1
@@ -1717,7 +1735,10 @@ run_one() {  # $1=idx $2=name $3=game $4=vbudget $5=xbudget
         [ "$xtag" = REGRESSION ] && xcell="$hx (>$xbudget FAIL)"
         [ "$xgtfail" = 1 ] && xcell="GT FAILED"
     else
-        hx=$xbudget; xtag=ok; xcell="(skipped)"
+        # Skipped: for GOLDEN_ONLY, treat as hx=0 so a clean golden is MATCH
+        # (xbudget is an FD residual, not a Scarier golden budget).
+        if [ "$GOLDEN_ONLY" = 1 ]; then hx=0; else hx=$xbudget; fi
+        xtag=ok; xcell="(skipped)"
     fi
     rm -f "$stxt"
 
@@ -1820,15 +1841,16 @@ echo
 echo "# TOTAL: $(cat "$WORKDIR"/*.row 2>/dev/null | awk '{print $2}' | sort | uniq -c |
                  awk '{printf "%s%s=%s", (NR>1 ? ", " : ""), $2, $1}')"
 echo "#"
-echo "# STATUS   MATCH     0 hunks in both modes"
+echo "# STATUS   MATCH     0 hunks in both modes (golden-only: golden match)"
 echo "#          DIVERGE   at baseline (see test/adrift5/notes/A5_WALKTHROUGH_FINDINGS.md)"
 echo "#          OKbetter  below baseline in some mode -- re-bless the MAP"
 echo "#          FAIL      exceeded a budget, OR the save/restore self-check"
 echo "#                    diverged (i.e. a regression), OR the ground truth"
 echo "#                    never ran for that mode (cell reads GT FAILED --"
 echo "#                    NOT a pass: nothing was compared)"
-echo "# COLUMNS  vanilla     FD stock System.Random"
-echo "#          xoshiro     FD_RNG=xoshiro aligned stream (XOSHIRO=0 skips)"
+echo "#          SKIP      game file absent, or (--golden-only) no expected.txt"
+echo "# COLUMNS  vanilla     FD stock System.Random (or golden strict-diff)"
+echo "#          xoshiro     FD_RNG=xoshiro aligned stream (XOSHIRO=0 / -g skips)"
 echo "#          saverestore mid-script A5_SAVE_AT round-trip must be"
 echo "#                      byte-identical (SAVERESTORE=0 skips)"
 

--- a/terps/scarier/test/adrift5/notes/A5_WALKTHROUGH_FINDINGS.md
+++ b/terps/scarier/test/adrift5/notes/A5_WALKTHROUGH_FINDINGS.md
@@ -33,19 +33,28 @@ bare commands) and replayed through **both** the Scarier harness
 ## Running
 
 ```sh
+# Default: Scarier in isolation (goldens only; no FrankenDrift / dotnet)
+make -f Makefile.headless test
+
+# Opt-in: full corpus vs FrankenDrift (needs FD.Headless + dotnet)
+make -f Makefile.headless test-fd
+# equivalents:
+make -f Makefile.headless a5walkthroughs
 make -f Makefile.headless a5run          # build test/adrift5/harness/a5run_dump
-# build FrankenDrift.Headless once (see a5_groundtruth.sh header)
-test/adrift5/harness/run_a5_walkthroughs.sh              # whole corpus, summary table
-test/adrift5/harness/run_a5_walkthroughs.sh -v Spectre   # one game, dump diff to /tmp/a5wt/
-test/adrift5/harness/a5_groundtruth.sh test/adrift5/games/<Game>.blorb test/adrift5/goldens/<Game>_walkthrough.txt
+test/adrift5/harness/run_a5_walkthroughs.sh
+test/adrift5/harness/run_a5_walkthroughs.sh -v Spectre   # one game, dump diff
+test/adrift5/harness/a5_groundtruth.sh test/adrift5/games/<Game>.blorb \
+    test/adrift5/goldens/<Game>_walkthrough.txt
 ```
 
-`run_a5_walkthroughs.sh` reports **MATCH** (Scarier == FrankenDrift),
-**DIVERGE n** (n diff hunks, at the per-game baseline budget recorded in the
-runner's MAP), **OKbetter** (below budget in some mode — that is a fix, re-bless
-the MAP row) or **FAIL** (over budget, or the save/restore self-check diverged —
-a regression). Games with a committed golden (`<Game>_expected.txt`) are
-strict-diffed against Scarier with no dotnet dependency.
+`make test` runs golden-backed a5 rows via `--golden-only` (SKIP if no
+`*_expected.txt`). `test-fd` / `run_a5_walkthroughs.sh` reports **MATCH**
+(Scarier == FrankenDrift), **DIVERGE n** (n diff hunks, at the per-game
+baseline budget recorded in the runner's MAP), **OKbetter** (below budget in
+some mode — that is a fix, re-bless the MAP row) or **FAIL** (over budget, or
+the save/restore self-check diverged — a regression). Games with a committed
+golden (`<Game>_expected.txt`) are strict-diffed against Scarier with no
+dotnet dependency.
 
 ## Corpus status
 


### PR DESCRIPTION
1. `run.sh` had a hard-coded absolute path to `/Users/administrator/spatterlight/terps/scarier`, which is fixed (and `A5WORK` is captured before `cd`, matching the documented default).

2. Default `make -f Makefile.headless test` is Scarier in isolation: it uses `--golden-only` for a5 walkthroughs (strict-diff committed `*_expected.txt`, SKIP rows without them). No FrankenDrift / dotnet required.

3. FrankenDrift comparison is opt-in via `make -f Makefile.headless test-fd` (alias of `a5walkthroughs`). That needs `FrankenDrift.Headless` from the `scarier-headless` branch of https://github.com/angstsmurf/frankendrift.

4. Separate commit folds `a5maptest` and `scprojregress` into the default isolation suite.

Rebased onto master (includes the silent-MATCH-without-FD guard from 8435779d). Dropped the unused `test-nofd` alias.