### PR TITLE
Scarier color fixes

### DIFF
--- a/terps/scarier/os_glk.cpp
+++ b/terps/scarier/os_glk.cpp
@@ -194,7 +194,7 @@ static int gsc_commands_enabled = TRUE,
    the adventure when it loads one.  See gsc_set_colour for where the numbers
    come from. */
 static glui32 gsc_colour_background = 0x000000,
-              gsc_colour_output = 0x00ff00,
+              gsc_colour_output = 0x19a58a,
               gsc_colour_input = 0xff3232;
 
 /* Whether the game's own palette is in force ("glk colour", set by
@@ -1773,12 +1773,11 @@ typedef enum {
  * Where the palette comes from differs by engine.  ADRIFT 5 stores it in the
  * adventure itself (a5model.h bg_colour and friends).  ADRIFT <=4 stores none:
  * the .taf has no colour fields, and the colours are Runner preferences.  The
- * defaults below are the ones run400.exe ships, read out of the settings it
- * writes under HKCU\Software\VB and VBA Program Settings\ADRIFT\Runner:
- * Background 0, Text1 3289855 and Text2 65280 -- OLE colour integers (low byte
- * red), i.e. black, #FF3232 for typed text and #00FF00 for replies.  They match
- * the swatches in the Runner's own Options -> Display & Media dialog ("Set
- * typed colour", "Set replies colour", "Set background colour").
+ * defaults below match the stock ADRIFT 3.90 / 4 Runner: black behind, teal
+ * #19A58A for replies (the same DEFAULT_OUTPUTCOLOUR ADRIFT 5 inherited), and
+ * #FF3232 for typed text / <c>.  They match the swatches in the Runner's own
+ * Options -> Display & Media dialog ("Set typed colour", "Set replies colour",
+ * "Set background colour").
  */
 /* GSC_HAVE_ZCOLORS, the palette itself and the on/off flag are all declared
    with the other module options at the top of the file, where the status line
@@ -3685,7 +3684,7 @@ gsc_command_verbose (const char *argument)
  *
  * Adrift games are written for a Runner that paints its output pane in a
  * palette of its own rather than in the interpreter's theme -- black behind,
- * green replies, red typed text for ADRIFT 4 (the Runner's defaults, and the
+ * teal replies, red typed text for ADRIFT <=4 (the Runner's defaults, and the
  * only place they live: nothing in the .taf carries a colour), the author's
  * own four colours for ADRIFT 5 -- and a game that writes white text, or
  * chooses colours to sit on black, needs that background to read at all.  Off

--- a/terps/scarier/os_glk.cpp
+++ b/terps/scarier/os_glk.cpp
@@ -2054,9 +2054,10 @@ gsc_colour_apply (winid_t win, glui32 fg)
 /*
  * gsc_colour_echo()
  *
- * Switch between the colour the player's typing is echoed in and the colour
- * the game's own text comes out in; see the forward declaration above
- * gsc_read_line_locale().
+ * Switch between the colour the player's typing is echoed in -- also the
+ * colour of the "> " command prompt, which the Runner paints the same way
+ * -- and the colour the game's own text comes out in; see the forward
+ * declaration above gsc_read_line_locale().
  */
 static void
 gsc_colour_echo (scr_bool typing)
@@ -5111,6 +5112,8 @@ os_read_line (scr_char *buffer, scr_int length)
     gsc_autorestored = FALSE;
   else
     {
+      /* Same ink as typed input when colour mode is on; see gsc_colour_echo. */
+      gsc_colour_echo (TRUE);
       gsc_put_literal (">");
       /* Autosave at every top-level prompt: after the prompt is printed (so
          the GUI snapshot ends with it) but before input is requested (so
@@ -5119,6 +5122,7 @@ os_read_line (scr_char *buffer, scr_int length)
       gsc_autosave ();
     }
 #else
+  gsc_colour_echo (TRUE);
   gsc_put_literal (">");
 #endif
 
@@ -6286,6 +6290,21 @@ gsc_a5_put_string (const char *string)
 }
 
 /*
+ * gsc_a5_put_prompt()
+ *
+ * Write the "> " the player types at.  In colour mode it uses the same ink
+ * as <c> / typed input (the Runner's "typed" colour), not the story's
+ * replies colour; callers print any leading newline themselves so that line
+ * break stays in the enclosing colour.
+ */
+static void
+gsc_a5_put_prompt (void)
+{
+  gsc_colour_echo (TRUE);
+  gsc_a5_put_string ("> ");
+}
+
+/*
  * gsc_a5_start_real_time()
  *
  * Decide whether this session runs the game's TimeBased events in real time,
@@ -6484,7 +6503,8 @@ gsc_a5_await_line (event_t *event, char *buf, int bufsize,
                 gsc_a5_status (gsc_a5_run);
                 if (a5run_is_over (gsc_a5_run))
                   return FALSE;
-                gsc_a5_put_string ("\n> ");
+                gsc_a5_put_string ("\n");
+                gsc_a5_put_prompt ();
 #ifdef SPATTERLIGHT
                 /* The tick changed game state while we sat at the prompt;
                    refresh the autosave (it skips itself when the
@@ -6714,7 +6734,8 @@ gsc_a5_popup_input (void * /*ctx*/, const char *prompt, const char *dflt)
       gsc_a5_put_string (dflt);
       gsc_a5_put_string ("]");
     }
-  gsc_a5_put_string ("\n> ");
+  gsc_a5_put_string ("\n");
+  gsc_a5_put_prompt ();
 
   /* This runs inside the engine (mid text-render), so a TimeBased tick must
      not re-enter it: hold real-time mode off for the duration, which also
@@ -6736,7 +6757,8 @@ gsc_a5_popup_input (void * /*ctx*/, const char *prompt, const char *dflt)
         {
           if (gsc_meta_pending == GSC_META_QUIT)
             glk_exit ();
-          gsc_a5_put_string ("\n> ");
+          gsc_a5_put_string ("\n");
+          gsc_a5_put_prompt ();
           continue;
         }
       break;
@@ -6816,7 +6838,8 @@ gsc_a5_popup_choice (void * /*ctx*/, const char *prompt,
       gsc_a5_put_string (choice1);
       gsc_a5_put_string (" / no = ");
       gsc_a5_put_string (choice2);
-      gsc_a5_put_string ("]\n> ");
+      gsc_a5_put_string ("]\n");
+      gsc_a5_put_prompt ();
 
       n = gsc_a5_read_line_raw (input, sizeof input);
 
@@ -9464,7 +9487,8 @@ gsc_a5_main (void)
         gsc_autorestored = FALSE;
       else
         {
-          gsc_a5_put_string ("\n> ");
+          gsc_a5_put_string ("\n");
+          gsc_a5_put_prompt ();
           /* Autosave at every top-level prompt: after the prompt is printed
              (so the GUI snapshot ends with it) but before input is
              requested (so the archived windows carry no pending request and
@@ -9472,7 +9496,8 @@ gsc_a5_main (void)
           gsc_autosave ();
         }
 #else
-      gsc_a5_put_string ("\n> ");
+      gsc_a5_put_string ("\n");
+      gsc_a5_put_prompt ();
 #endif
       if (gsc_a5_read_line (input, sizeof input) == 0)
         continue;

--- a/terps/scarier/os_glk.cpp
+++ b/terps/scarier/os_glk.cpp
@@ -195,7 +195,7 @@ static int gsc_commands_enabled = TRUE,
    come from. */
 static glui32 gsc_colour_background = 0x000000,
               gsc_colour_output = 0x19a58a,
-              gsc_colour_input = 0xff3232;
+              gsc_colour_input = 0xd22527;
 
 /* Whether the game's own palette is in force ("glk colour", set by
    gsc_set_colour far below).  It lives up here because the status line, drawn
@@ -1774,10 +1774,10 @@ typedef enum {
  * adventure itself (a5model.h bg_colour and friends).  ADRIFT <=4 stores none:
  * the .taf has no colour fields, and the colours are Runner preferences.  The
  * defaults below match the stock ADRIFT 3.90 / 4 Runner: black behind, teal
- * #19A58A for replies (the same DEFAULT_OUTPUTCOLOUR ADRIFT 5 inherited), and
- * #FF3232 for typed text / <c>.  They match the swatches in the Runner's own
- * Options -> Display & Media dialog ("Set typed colour", "Set replies colour",
- * "Set background colour").
+ * #19A58A for replies and #D22527 for typed text / <c> (the same
+ * DEFAULT_OUTPUTCOLOUR / DEFAULT_INPUTCOLOUR ADRIFT 5 inherited).  They match
+ * the swatches in the Runner's own Options -> Display & Media dialog ("Set
+ * typed colour", "Set replies colour", "Set background colour").
  */
 /* GSC_HAVE_ZCOLORS, the palette itself and the on/off flag are all declared
    with the other module options at the top of the file, where the status line


### PR DESCRIPTION
1. Render command prompt `> ` in command-prompt color (we were rendering it in the normal-text color)
2. Fix A3/A4 normal text color. Fixes #139
3. Fix A3/A4 command text color