### PR TITLE
scarier: remove unneeded `glk colour` option; enable color by default

### DIFF
--- a/terps/scarier/adrift5/a5model.cpp
+++ b/terps/scarier/adrift5/a5model.cpp
@@ -3,6 +3,7 @@
  * ADRIFT 5 support for Scarier -- in-memory object model.  See a5model.h.
  */
 
+#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1442,6 +1443,99 @@ a5model_load_error (const a5_adventure_t *a)
   if (a == NULL || a->n_locations == 0)
     return "This adventure has no locations.  Cannot continue.";
   return NULL;
+}
+
+/* Case-insensitive match of `prefix` at `s`; returns the length matched, or 0. */
+static int
+a5_ci_prefix_len (const char *s, const char *prefix)
+{
+  int n = 0;
+  while (prefix[n] != '\0')
+    {
+      if (s[n] == '\0'
+          || tolower ((unsigned char) s[n]) != tolower ((unsigned char) prefix[n]))
+        return 0;
+      n++;
+    }
+  return n;
+}
+
+/* True when `text` (already entity-decoded adventure string content) contains
+   a <font ... color=...> or <font ... colour=...> open tag.  Face/size-only
+   <font> tags do not count: those are typography, not a colour choice. */
+static int
+a5_text_has_font_colour (const char *text)
+{
+  const char *p;
+
+  if (text == NULL)
+    return 0;
+  for (p = text; *p != '\0'; p++)
+    {
+      const char *gt, *q;
+      int namelen;
+      char after;
+
+      if (*p != '<')
+        continue;
+      namelen = a5_ci_prefix_len (p + 1, "font");
+      if (namelen == 0)
+        continue;
+      after = p[1 + namelen];
+      if (after != '\0' && after != '>' && !isspace ((unsigned char) after))
+        continue;
+      gt = strchr (p + 1, '>');
+      if (gt == NULL)
+        break;
+      for (q = p + 1 + namelen; q < gt; q++)
+        {
+          int attr = a5_ci_prefix_len (q, "colour");
+          if (attr == 0)
+            attr = a5_ci_prefix_len (q, "color");
+          if (attr == 0)
+            continue;
+          q += attr;
+          while (q < gt && isspace ((unsigned char) *q))
+            q++;
+          if (q < gt && *q == '=')
+            return 1;
+        }
+      p = gt;
+    }
+  return 0;
+}
+
+static int
+a5_node_has_font_colour (const a5_xml_node_t *n)
+{
+  const a5_xml_node_t *c;
+
+  if (n == NULL)
+    return 0;
+  if (n->text != NULL && n->text[0] != '\0' && a5_text_has_font_colour (n->text))
+    return 1;
+  for (c = n->first_child; c != NULL; c = c->next)
+    {
+      if (a5_node_has_font_colour (c))
+        return 1;
+    }
+  return 0;
+}
+
+int
+a5model_uses_custom_colour (const a5_adventure_t *a)
+{
+  /* Runner defaults from Global.vb DEFAULT_*COLOUR, held here as 0xRRGGBB --
+     the same values a5model_from_doc writes when the adventure omits a colour
+     element (see the A5_COLOURS table there). */
+  if (a == NULL)
+    return 0;
+  if (a->bg_colour != 0x000000u
+      || a->input_colour != 0xd22527u
+      || a->output_colour != 0x19a58au
+      || a->link_colour != 0x4bd7bcu)
+    return 1;
+  return a5_node_has_font_colour (a->root);
 }
 
 void

--- a/terps/scarier/adrift5/a5model.h
+++ b/terps/scarier/adrift5/a5model.h
@@ -436,6 +436,12 @@ extern int a5model_upgrade_forced_yes (const a5_adventure_t *a);
  */
 extern const char *a5model_load_error (const a5_adventure_t *a);
 
+/* Non-zero when the adventure asks for a non-default Runner palette, or embeds
+   a <font colour="..."> / <font color="..."> tag anywhere in its XML text.
+   Hosts that prefer the interpreter theme for stock ADRIFT colours use this to
+   decide whether to paint the game's own palette. */
+extern int a5model_uses_custom_colour (const a5_adventure_t *a);
+
 extern void a5model_free (a5_adventure_t *adv);
 
 /* Property lookup within a record's property array. */

--- a/terps/scarier/adrift5/a5text.h
+++ b/terps/scarier/adrift5/a5text.h
@@ -114,7 +114,7 @@
      - <c> and <font colour="..."> leave an A5_COLOUR_MARK-delimited colour
        span, \027<value>\027, and their close tags leave A5_ENDCOLOUR_MARK, so
        the host can draw the enclosed text in the Adrift colour the author
-       asked for (a Glk host through garglk_set_zcolors, under "glk colour").
+       asked for (a Glk host through garglk_set_zcolors).
        <value> is the tag's colour token verbatim and lowercased -- a name
        ("red"), a hex triplet ("#ff0000") -- or empty for a <font> that names
        no colour, which inherits the enclosing one so that its </font> still

--- a/terps/scarier/os_glk.cpp
+++ b/terps/scarier/os_glk.cpp
@@ -18,12 +18,15 @@
  */
 
 /*
- * Module notes:
- *
- * o The Glk interface makes no effort to set text colours, background
- *   colours, and so forth, and minimal effort to set fonts and other style
- *   effects.
- */
+  * Module notes:
+  *
+  * o Where the Glk library has garglk_set_zcolors (Spatterlight, Gargoyle),
+  *   the port paints the story in the game's own Adrift palette when the
+  *   adventure customises colour (a non-default ADRIFT 5 header palette, a
+  *   <font colour>/<bgcolour> tag, or "glk colour on" / "-c").  Elsewhere it
+  *   makes no effort to set text or background colours, and minimal effort to
+  *   set fonts and other style effects.
+  */
 
 #include <assert.h>
 #include <ctype.h>
@@ -181,26 +184,27 @@ static int gsc_commands_enabled = TRUE,
            gsc_unicode_enabled = TRUE;
 
 /* Whether this Glk library has the garglk_set_zcolors extension, and with it
-   the "glk colour" mode.  Defined up here rather than down with the rest of
+   Adrift colour painting.  Defined up here rather than down with the rest of
    the colour code because the status line, drawn earlier in the file, draws
    itself in the game's colours too; the mode itself is documented where
-   gsc_set_colour lives. */
+   gsc_colour_startup_apply lives. */
 #if defined(SPATTERLIGHT) || defined(GARGLK) \
     || defined(GLK_MODULE_GARGLK_FILE_RESOURCES)
 # define GSC_HAVE_ZCOLORS 1
 #endif
 
 /* ADRIFT <=4 Runner default palette; the ADRIFT 5 loop overwrites these from
-   the adventure when it loads one.  See gsc_set_colour for where the numbers
-   come from. */
+   the adventure when it loads one.  See gsc_colour_startup_apply for where the
+   numbers come from. */
 static glui32 gsc_colour_background = 0x000000,
               gsc_colour_output = 0x00ff00,
               gsc_colour_input = 0xff3232;
 
-/* Whether the game's own palette is in force ("glk colour", set by
-   gsc_set_colour far below).  It lives up here because the status line, drawn
-   earlier in the file, picks its style by it; where the Glk library has no
-   zcolors extension the command is not offered and this stays FALSE. */
+/* Whether the game's own palette is in force ("glk colour", also set
+   automatically when an adventure customises colour).  It lives up here
+   because the status line, drawn earlier in the file, picks its style by it;
+   where the Glk library has no zcolors extension the command is not offered
+   and this stays FALSE. */
 static int gsc_colour_enabled = FALSE;
 /* Whether the "-c" command line switch asked for colour mode from the start,
    sparing the player a "glk colour on" at every launch.  Acted on once the
@@ -210,8 +214,8 @@ static int gsc_colour_startup = FALSE;
    the status bar in its own two colours can put the story's back afterwards --
    a library whose zcolors are global as well as per-stream would otherwise go
    on painting the story window in the bar's colours.  See gsc_status_end.  Only
-   read while colour mode is on, and gsc_set_colour colours the story window
-   before it turns the mode on, so it is always set by then. */
+   read while colour mode is on, and gsc_colour_startup_apply colours the story
+   window before any status redraw, so it is always set by then. */
 static glui32 gsc_colour_main_fg = 0;
 
 /* Adrift game to interpret. */
@@ -1175,9 +1179,8 @@ gsc_unicode_buffer_to_locale (const glui32 *unicode, scr_int length,
 }
 
 
-/* Colour mode; defined with the rest of the style handling further down.
-   Switches later text between the game's typed colour and its normal one, and
-   does nothing at all unless colour mode is on. */
+/* Adrift colours; defined with the rest of the style handling further down.
+   Switches later text between the game's typed colour and its normal one. */
 static void gsc_colour_echo (scr_bool typing);
 
 
@@ -1766,22 +1769,22 @@ typedef enum {
  * (replies) colour for the story, and an "input" (typed) colour that <c>...</c>
  * also asks for, on top of whatever <font colour="..."> the text names.  Glk
  * has no colour of its own, so by default this port drops all of that and
- * shows the story in the interpreter's styles, as SCARE always has.
+ * shows the story in the interpreter's styles.
  *
- * "glk colour on" turns the palette back on, through the Gargoyle/Spatterlight
- * garglk_set_zcolors extension.  Where that extension is missing (cheapglk,
- * glkterm) the mode cannot be offered at all, so everything below compiles out
- * and the command says so.
+ * When an adventure customises colour -- a non-default ADRIFT 5 header palette,
+ * or a <font colour>/<font color> (or ADRIFT <=4 <bgcolour>) tag anywhere in
+ * the game -- the port turns the palette on automatically through the
+ * Gargoyle/Spatterlight garglk_set_zcolors extension.  "glk colour on/off"
+ * still lets the player opt in to the Runner defaults or opt out of author
+ * colours.  Where that extension is missing (cheapglk, glkterm) the mode
+ * cannot be offered at all, so everything below compiles out and the command
+ * says so.
  *
  * Where the palette comes from differs by engine.  ADRIFT 5 stores it in the
- * adventure itself (a5model.h bg_colour and friends).  ADRIFT <=4 stores none:
- * the .taf has no colour fields, and the colours are Runner preferences.  The
- * defaults below are the ones run400.exe ships, read out of the settings it
- * writes under HKCU\Software\VB and VBA Program Settings\ADRIFT\Runner:
- * Background 0, Text1 3289855 and Text2 65280 -- OLE colour integers (low byte
- * red), i.e. black, #FF3232 for typed text and #00FF00 for replies.  They match
- * the swatches in the Runner's own Options -> Display & Media dialog ("Set
- * typed colour", "Set replies colour", "Set background colour").
+ * adventure itself (a5model.h bg_colour and friends).  ADRIFT <=4 stores none
+ * in the header: the .taf has no colour fields, and the colours below are
+ * run400.exe's defaults (Background 0, Text1 3289855, Text2 65280 -- OLE
+ * integers, i.e. black, #FF3232 typed, #00FF00 replies).
  */
 /* GSC_HAVE_ZCOLORS, the palette itself and the on/off flag are all declared
    with the other module options at the top of the file, where the status line
@@ -3731,10 +3734,11 @@ gsc_command_verbose (const char *argument)
  * green replies, red typed text for ADRIFT 4 (the Runner's defaults, and the
  * only place they live: nothing in the .taf carries a colour), the author's
  * own four colours for ADRIFT 5 -- and a game that writes white text, or
- * chooses colours to sit on black, needs that background to read at all.  Off
- * by default, since the interpreter's own theme is what most players want;
- * a player who wants the Runner's look every time starts the interpreter with
- * "-c" (gsc_colour_startup_apply).
+ * chooses colours to sit on black, needs that background to read at all.
+ * Colour mode also starts on automatically when the adventure customises
+ * colour (see gsc_colour_startup_apply); "glk colour" is still here so a
+ * player can opt into the Runner defaults or opt out of author colours.
+ * A player who wants the Runner's look every time starts with "-c".
  *
  * Turning it on clears the window so the background is black from the top
  * rather than only behind text written from here on; turning it off clears
@@ -3837,18 +3841,20 @@ gsc_set_colour (scr_bool state)
 /*
  * gsc_colour_startup_apply()
  *
- * Act on the "-c" switch, once the story and status windows exist and the
- * ADRIFT 5 loader (if any) has replaced the palette globals with the
- * adventure's own four colours -- both true by the time either main() calls
- * this.  Not called on an autorestore: a restored session brings its own
- * colour state back with it, and a switch on the command line has no business
- * overriding what the player left the game in.
+ * Paint the story in the game's Adrift palette once the windows exist, when
+ * either "-c" asked for colour mode or load-time detection decided the
+ * adventure customises colour (a5model_uses_custom_colour /
+ * scr_game_uses_custom_colour) -- both the windows and the palette globals are
+ * ready by the time either main() calls this.  Not called on an autorestore: a
+ * restored session brings its own colour state back with it, and a switch on
+ * the command line has no business overriding what the player left the game
+ * in.
  */
 static void
 gsc_colour_startup_apply (void)
 {
 #ifdef GSC_HAVE_ZCOLORS
-  if (gsc_colour_startup)
+  if (gsc_colour_startup || gsc_colour_enabled)
     gsc_set_colour (TRUE);
 #endif
 }
@@ -4840,10 +4846,13 @@ gsc_command_help (const char *command)
       gsc_standout_string ("glk colours");
       gsc_normal_string (", and ");
       gsc_standout_string ("glk colors");
-      gsc_normal_string (" are the same command.\n\nGames written for a black"
-                         " screen can be hard to read without this; games that"
-                         " never set a colour of their own look much the same"
-                         " either way.\n");
+      gsc_normal_string (" are the same command.\n\nColour mode also starts on"
+                         " by itself when the adventure customises colour"
+                         " (a non-default ADRIFT 5 palette, or a"
+                         " <font colour>/<bgcolour> tag).  Games written for a"
+                         " black screen can be hard to read without this;"
+                         " games that never set a colour of their own look"
+                         " much the same either way.\n");
     }
 
   else if (matched->handler == gsc_command_undo
@@ -5969,10 +5978,12 @@ gsc_startup_code (strid_t game_stream, strid_t restore_stream,
           gsc_game_message = NULL;
           /* Unlike ADRIFT 4, where the palette is a Runner preference the .taf
              knows nothing about, an ADRIFT 5 adventure carries the author's
-             own colours; colour mode uses those. */
+             own colours.  Honour them only when the adventure customises
+             colour -- otherwise leave the interpreter theme alone. */
           gsc_colour_background = gsc_a5_adv->bg_colour;
           gsc_colour_output = gsc_a5_adv->output_colour;
           gsc_colour_input = gsc_a5_adv->input_colour;
+          gsc_colour_enabled = a5model_uses_custom_colour (gsc_a5_adv);
           glk_stream_close (game_stream, NULL);
           if (restore_stream)
             glk_stream_close (restore_stream, NULL);
@@ -6034,6 +6045,10 @@ gsc_startup_code (strid_t game_stream, strid_t restore_stream,
       /* Default the assists on for known broken games, before the game's
          battle_start() reads the combat-assist flag. */
       gsc_apply_known_game_assists (gsc_game);
+
+      /* ADRIFT <=4 colour lives only as tags inside authored strings; start
+         in the Runner palette when the TAF embeds any. */
+      gsc_colour_enabled = scr_game_uses_custom_colour (gsc_game);
     }
 
   /* Close the temporary window. */
@@ -6099,7 +6114,8 @@ gsc_main (void)
 
       gsc_open_status_window ();
 
-      /* "-c": into the game's palette before a word is printed. */
+      /* "-c", or an adventure that customises colour: into the game's palette
+         before a word is printed. */
       gsc_colour_startup_apply ();
     }
 
@@ -8462,11 +8478,6 @@ gsc_map_redraw (void)
   if (w == 0 || h == 0)
     return;
 
-  /* The map is drawn in the story's colours: the buffer's normal style
-     supplies the background and text colour.  Spatterlight answers
-     glk_style_measure with the live theme, and redraws on both prompt and
-     arrange, so a theme change reaches the map by itself; a Glk that cannot
-     measure leaves the palette at its black-on-white default. */
   {
     glui32 bg, fg;
     scr_bool have;
@@ -8487,6 +8498,9 @@ gsc_map_redraw (void)
       }
     else
 #endif
+      /* The map is drawn in the story's colours: the buffer's normal style
+         supplies the background and text colour.  A Glk that cannot measure
+         leaves the palette at its black-on-white default. */
       have = glk_style_measure (gsc_main_window, style_Normal,
                                 stylehint_BackColor, &bg)
              && glk_style_measure (gsc_main_window, style_Normal,
@@ -9375,8 +9389,8 @@ gsc_a5_main (void)
       gsc_open_main_window ();
       gsc_open_status_window ();
 
-      /* "-c": into the adventure's own palette (already parsed off the header
-         by the startup code) before the title page is drawn. */
+      /* "-c", or an adventure that customises colour: into the adventure's
+         own palette before the title page is drawn. */
       gsc_colour_startup_apply ();
     }
 

--- a/terps/scarier/scarier.h
+++ b/terps/scarier/scarier.h
@@ -158,6 +158,9 @@ extern void scr_set_game_capacity_recompute (scr_game game, scr_bool flag);
 
 extern scr_bool scr_does_game_use_sounds (scr_game);
 extern scr_bool scr_does_game_use_graphics (scr_game);
+/* Non-zero when the TAF embeds colour markup (<font colour>/<font color> or
+   <bgcolour>/<bgcolor>) anywhere in its authored strings. */
+extern scr_bool scr_game_uses_custom_colour (scr_game);
 
 typedef void *scr_game_hint;
 extern scr_game_hint scr_get_first_game_hint (scr_game game);

--- a/terps/scarier/scinterf.cpp
+++ b/terps/scarier/scinterf.cpp
@@ -24,6 +24,7 @@
  */
 
 #include <assert.h>
+#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1334,6 +1335,116 @@ scr_does_game_use_graphics (scr_game game)
     return FALSE;
 
   return res_has_graphics (game_);
+}
+
+
+/* Case-insensitive match of `prefix` at `s`; returns the length matched, or 0. */
+static int
+scr_ci_prefix_len (const char *s, const char *prefix)
+{
+  int n = 0;
+  while (prefix[n] != '\0')
+    {
+      if (s[n] == '\0'
+          || tolower ((unsigned char) s[n]) != tolower ((unsigned char) prefix[n]))
+        return 0;
+      n++;
+    }
+  return n;
+}
+
+/*
+ * True when `text` contains a <font ... color=...> / <font ... colour=...> open
+ * tag, or a <bgcolour=...> / <bgcolor=...> void tag.  Face/size-only <font>
+ * tags do not count.
+ */
+static scr_bool
+scr_text_has_colour_markup (const char *text)
+{
+  const char *p;
+
+  if (text == NULL)
+    return FALSE;
+  for (p = text; *p != '\0'; p++)
+    {
+      const char *gt, *q;
+      int namelen;
+      char after;
+
+      if (*p != '<')
+        continue;
+
+      /* <bgcolour=...> / <bgcolor=...> repaint the Runner output pane. */
+      namelen = scr_ci_prefix_len (p + 1, "bgcolour");
+      if (namelen == 0)
+        namelen = scr_ci_prefix_len (p + 1, "bgcolor");
+      if (namelen != 0)
+        {
+          q = p + 1 + namelen;
+          while (*q != '\0' && *q != '>' && isspace ((unsigned char) *q))
+            q++;
+          if (*q == '=')
+            return TRUE;
+        }
+
+      namelen = scr_ci_prefix_len (p + 1, "font");
+      if (namelen == 0)
+        continue;
+      after = p[1 + namelen];
+      if (after != '\0' && after != '>' && !isspace ((unsigned char) after))
+        continue;
+      gt = strchr (p + 1, '>');
+      if (gt == NULL)
+        break;
+      for (q = p + 1 + namelen; q < gt; q++)
+        {
+          int attr = scr_ci_prefix_len (q, "colour");
+          if (attr == 0)
+            attr = scr_ci_prefix_len (q, "color");
+          if (attr == 0)
+            continue;
+          q += attr;
+          while (q < gt && isspace ((unsigned char) *q))
+            q++;
+          if (q < gt && *q == '=')
+            return TRUE;
+        }
+      p = gt;
+    }
+  return FALSE;
+}
+
+/*
+ * scr_game_uses_custom_colour()
+ *
+ * Scan every TAF line for colour markup.  ADRIFT <=4 stores no palette in the
+ * file header -- colour lives only as tags inside authored strings -- so this
+ * is how the Glk port decides whether to start in the Runner's palette.
+ */
+scr_bool
+scr_game_uses_custom_colour (scr_game game)
+{
+  const scr_gameref_t game_ = (scr_gameref_t) game;
+  scr_prop_setref_t bundle;
+  scr_tafref_t taf;
+  const scr_char *line;
+
+  if (if_game_error (game_, "scr_game_uses_custom_colour"))
+    return FALSE;
+
+  bundle = gs_get_bundle (game_);
+  taf = prop_get_taf (bundle);
+  if (taf == NULL)
+    return FALSE;
+
+  taf_first_line (taf);
+  while (taf_more_lines (taf))
+    {
+      line = taf_next_line (taf);
+      if (line != NULL && scr_text_has_colour_markup (line))
+        return TRUE;
+    }
+  return FALSE;
 }
 
 

--- a/terps/scarier/scprops.cpp
+++ b/terps/scarier/scprops.cpp
@@ -1064,6 +1064,14 @@ prop_adopt (scr_prop_setref_t bundle, void *addr)
 }
 
 
+scr_tafref_t
+prop_get_taf (scr_prop_setref_t bundle)
+{
+  assert (prop_is_valid (bundle));
+  return bundle->taf;
+}
+
+
 /*
  * prop_debug_is_dictionary_string()
  * prop_debug_dump_node()

--- a/terps/scarier/scprotos.h
+++ b/terps/scarier/scprotos.h
@@ -217,6 +217,8 @@ extern scr_bool prop_put_string (scr_prop_setref_t bundle,
 extern void prop_adopt (scr_prop_setref_t bundle, void *addr);
 extern void prop_debug_trace (scr_bool flag);
 extern void prop_debug_dump (scr_prop_setref_t bundle);
+/* The TAF the properties were parsed from (for scanning authored strings). */
+extern scr_tafref_t prop_get_taf (scr_prop_setref_t bundle);
 
 /* Game parser enumeration and functions. */
 enum


### PR DESCRIPTION
The "Games can set colors and styles" user setting can be used to enable/disable colors in a user-discoverable way.