### PR TITLE
Load game data from open buffer for Emglken compatibility

### DIFF
--- a/terps/scarier/adrift5/a5model.cpp
+++ b/terps/scarier/adrift5/a5model.cpp
@@ -1126,12 +1126,10 @@ a5_scan_release (const uint8_t *buf, uint32_t len)
 }
 
 a5_adventure_t *
-a5model_load (const char *path)
+a5model_load_buffer (uint8_t *file_buf, uint32_t file_len)
 {
-  FILE *fp;
-  long size;
-  uint8_t *file_buf, *payload;
-  uint32_t file_len, payload_len, header, region_len, xml_len;
+  uint8_t *payload;
+  uint32_t payload_len, header, region_len, xml_len;
   uint8_t *xml;
   char *ifid;
   char *release;
@@ -1139,26 +1137,11 @@ a5model_load (const char *path)
   a5_xml_doc_t *doc;
   a5_adventure_t *adv;
 
-  fp = fopen (path, "rb");
-  if (fp == NULL)
-    return NULL;
-  fseek (fp, 0, SEEK_END);
-  size = ftell (fp);
-  fseek (fp, 0, SEEK_SET);
-  if (size <= 0)
-    {
-      fclose (fp);
-      return NULL;
-    }
-  file_buf = (uint8_t *) malloc ((size_t) size);
-  if (file_buf == NULL || fread (file_buf, 1, (size_t) size, fp) != (size_t) size)
+  if (file_buf == NULL || file_len == 0)
     {
       free (file_buf);
-      fclose (fp);
       return NULL;
     }
-  fclose (fp);
-  file_len = (uint32_t) size;
 
   int from_blorb;
   if (a5blorb_find_exec (file_buf, file_len, &chunk))
@@ -1311,6 +1294,35 @@ a5model_load (const char *path)
       adv->map_pane_open = map_pane_open;
     }
   return adv;
+}
+
+a5_adventure_t *
+a5model_load (const char *path)
+{
+  FILE *fp;
+  long size;
+  uint8_t *file_buf;
+
+  fp = fopen (path, "rb");
+  if (fp == NULL)
+    return NULL;
+  fseek (fp, 0, SEEK_END);
+  size = ftell (fp);
+  fseek (fp, 0, SEEK_SET);
+  if (size <= 0)
+    {
+      fclose (fp);
+      return NULL;
+    }
+  file_buf = (uint8_t *) malloc ((size_t) size);
+  if (file_buf == NULL || fread (file_buf, 1, (size_t) size, fp) != (size_t) size)
+    {
+      free (file_buf);
+      fclose (fp);
+      return NULL;
+    }
+  fclose (fp);
+  return a5model_load_buffer (file_buf, (uint32_t) size);
 }
 
 /* ---------------------------------------- "Adventure Upgrade" (FileIO.vb) */

--- a/terps/scarier/adrift5/a5model.h
+++ b/terps/scarier/adrift5/a5model.h
@@ -401,6 +401,11 @@ extern int a5model_key_index (const a5_adventure_t *a, int kind, const char *key
 /* Full pipeline: read a Blorb/.taf file, deobfuscate, inflate, parse, model. */
 extern a5_adventure_t *a5model_load (const char *path);
 
+/* Same pipeline from an in-memory file image. Takes ownership of file_buf
+   (always frees it, including on failure). Used by Glk hosts that already have
+   the game open as a stream (e.g. Emglken with FILESYSTEM=0). */
+extern a5_adventure_t *a5model_load_buffer (uint8_t *file_buf, uint32_t file_len);
+
 /*
  * The "Adventure Upgrade" question (FileIO.vb:634, headless answer semantics in
  * FrankenDrift.Headless AskYesNoQuestion): when a5model_upgrade_pending returns

--- a/terps/scarier/os_glk.cpp
+++ b/terps/scarier/os_glk.cpp
@@ -6390,15 +6390,38 @@ gsc_startup_code (strid_t game_stream, strid_t restore_stream,
   /*
    * ADRIFT 5 detection.  ADRIFT 5 games are zlib-compressed XML (optionally
    * Blorb-wrapped) and unrelated to the ADRIFT <=4 TAF format the scare engine
-   * reads.  a5model_load returns NULL cleanly for a non-ADRIFT-5 file, so we
-   * try it first; on success we run the dedicated a5 turn loop (gsc_a5_main)
-   * and skip the scare path entirely.  a5model_load reads the file by path, so
-   * this requires gsc_game_path to have been set by the startup code.
+   * reads.  a5model_load_buffer returns NULL cleanly for a non-ADRIFT-5 file, so
+   * we try it first from the already-open Glk stream; on success we run the
+   * dedicated a5 turn loop (gsc_a5_main) and skip the scare path entirely.
+   *
+   * Loading from the Glk stream (rather than fopen of gsc_game_path) is required
+   * for hosts like Emglken that open the story via Dialog with FILESYSTEM=0.
    */
-  if (gsc_game_path[0] != '\0')
-    {
-      gsc_a5_adv = a5model_load (gsc_game_path);
-      if (gsc_a5_adv)
+  {
+    glui32 file_len;
+    char *file_buf;
+    glui32 got;
+
+    glk_stream_set_position (game_stream, 0, seekmode_End);
+    file_len = glk_stream_get_position (game_stream);
+    glk_stream_set_position (game_stream, 0, seekmode_Start);
+
+    if (file_len > 0)
+      {
+        file_buf = (char *) malloc (file_len);
+        if (file_buf != NULL)
+          {
+            got = glk_get_buffer_stream (game_stream, file_buf, file_len);
+            /* Rewind for the ADRIFT <=4 path if A5 load fails. */
+            glk_stream_set_position (game_stream, 0, seekmode_Start);
+            if (got == file_len)
+              gsc_a5_adv = a5model_load_buffer ((uint8_t *) file_buf, file_len);
+            else
+              free (file_buf);
+          }
+      }
+
+    if (gsc_a5_adv)
         {
           gsc_is_a5 = TRUE;
           gsc_game = NULL;
@@ -6436,7 +6459,7 @@ gsc_startup_code (strid_t game_stream, strid_t restore_stream,
 #endif
           return TRUE;
         }
-    }
+  }
 
   gsc_game = scr_game_from_callback (gsc_callback, game_stream);
   if (!gsc_game)
@@ -10452,8 +10475,9 @@ glkunix_startup_code (glkunix_startup_t * data)
       return TRUE;
     }
 
-  /* Remember the game file path; the ADRIFT 5 loader (a5model_load) reads the
-   * file directly by path rather than through a Glk stream. */
+  /* Remember the game file path for hosts that reopen it (graphics/sound via
+   * glkunix_stream_open_pathname). ADRIFT 5 game data itself is loaded from the
+   * Glk stream above via a5model_load_buffer. */
   snprintf (gsc_game_path, sizeof gsc_game_path, "%s", argv[argv_index]);
 
   /* Open a stream to the TAF file, complain if this fails. */


### PR DESCRIPTION
Emglken sets `FILESYSTEM=0`, preventing `fopen` etc. from working.