### PR TITLE
scarier: implement panning/zooming controls on the graphics-window map

### DIFF
--- a/terps/scarier/mapdraw.cpp
+++ b/terps/scarier/mapdraw.cpp
@@ -1037,9 +1037,18 @@ typedef struct {
 static void
 proj_init (proj_t *p, const map_camera_t *cam, const map_surface_t *dst)
 {
+  int chrome = cam->chrome_h;
+  int content_h;
+
+  if (chrome < 0)
+    chrome = 0;
+  if (chrome > dst->h)
+    chrome = dst->h;
+  content_h = dst->h - chrome;
   p->cam = cam;
   p->ox = dst->w / 2 - cam->cx;
-  p->oy = dst->h / 2 - cam->cy;
+  /* Centre the view in the content area under the floating chrome. */
+  p->oy = chrome + content_h / 2 - cam->cy;
 }
 
 static int
@@ -1429,29 +1438,60 @@ map_zoom_step (int scale, int dir)
   return scale;
 }
 
-void
+int
 map_frame (const map_t *map, const map_view_t *view,
-             const char *player_key, const map_surface_t *dst,
-             int zoom, map_camera_t *cam)
+           const char *player_key, const map_surface_t *dst,
+           int zoom, int follow, int chrome_h, map_camera_t *cam,
+           int *out_fit_scale)
 {
   const map_node_t *pn;
   const map_page_t *page;
   int i, minx = 0, miny = 0, maxx = 0, maxy = 0, first = 1;
-  int sx, sy, scale;
+  int sx, sy, scale, fit_scale;
+  int content_w, content_h, margin = 24;
+  int spanx, spany, fits_x, fits_y, fits;
+  int prev_cx, prev_cy, prev_page;
+  int follow_now;
+  int cx, cy, lo, hi;
 
-  cam->page = 0;
+  if (cam == NULL)
+    return 0;
+  prev_cx = cam->cx;
+  prev_cy = cam->cy;
+  prev_page = cam->page;
+  if (chrome_h < 0)
+    chrome_h = 0;
+  cam->chrome_h = chrome_h;
   cam->scale = 10;
-  cam->cx = 0;
-  cam->cy = 0;
   if (map == NULL || dst == NULL)
-    return;
+    {
+      if (out_fit_scale)
+        *out_fit_scale = MAP_SCALE_MAX;
+      return 1;
+    }
+
+  content_w = dst->w;
+  content_h = dst->h - chrome_h;
+  if (content_h < 1)
+    content_h = 1;
 
   pn = map_find (map, player_key);
-  player_page_key (map, player_key, &cam->page);
+  /* Stay on the player's page while they are on a visible map room; a hidden
+     or unplaced room keeps the previous page so the view does not jump. */
+  if (pn != NULL && !pn->hidden)
+    cam->page = pn->page;
+  else if (page_by_key (map, prev_page) != NULL)
+    cam->page = prev_page;
+  else if (!player_page_key (map, player_key, &cam->page))
+    cam->page = 0;
 
   page = page_by_key (map, cam->page);
   if (page == NULL)
-    return;
+    {
+      if (out_fit_scale)
+        *out_fit_scale = MAP_SCALE_MAX;
+      return 1;
+    }
 
   for (i = 0; i < page->n_nodes; i++)
     {
@@ -1479,56 +1519,407 @@ map_frame (const map_t *map, const map_view_t *view,
         }
     }
   if (first)
-    return;                     /* nothing seen yet */
-
-  /* Fit the seen extent, with a margin for the labels and out-arrows -- unless
-     a manual zoom has pinned the scale, when only the centring below runs. */
-  if (zoom > 0)
-    scale = zoom;
-  else
     {
-      sx = (maxx - minx) > 0 ? (dst->w - 24) / (maxx - minx) : MAP_SCALE_MAX;
-      sy = (maxy - miny) > 0 ? (dst->h - 24) / (maxy - miny) : MAP_SCALE_MAX;
-      scale = sx < sy ? sx : sy;
-      if (scale > MAP_SCALE_MAX)
-        scale = MAP_SCALE_MAX;
-      if (scale < MAP_SCALE_MIN)
-        scale = MAP_SCALE_MIN;
+      if (out_fit_scale)
+        *out_fit_scale = MAP_SCALE_MAX;
+      return 1;                 /* nothing seen yet */
     }
+
+  /* Auto-fit into the content area under the chrome, with a margin for the
+     labels and out-arrows. */
+  sx = (maxx - minx) > 0 ? (content_w - margin) / (maxx - minx) : MAP_SCALE_MAX;
+  sy = (maxy - miny) > 0 ? (content_h - margin) / (maxy - miny) : MAP_SCALE_MAX;
+  fit_scale = sx < sy ? sx : sy;
+  if (fit_scale > MAP_SCALE_MAX)
+    fit_scale = MAP_SCALE_MAX;
+  if (fit_scale < MAP_SCALE_MIN)
+    fit_scale = MAP_SCALE_MIN;
+  if (out_fit_scale)
+    *out_fit_scale = fit_scale;
+
+  scale = zoom > 0 ? zoom : fit_scale;
   cam->scale = scale;
 
-  /* Centre the seen extent when it fits at this scale (CentreMap); once it is
-     too big to show at once, follow the player instead (LockPlayerCentre) and
-     clamp so we never scroll past the edge of the map. */
-  cam->cx = (int) ((minx + maxx) / 2.0 * scale);
-  cam->cy = (int) ((miny + maxy) / 2.0 * scale);
+  spanx = (maxx - minx) * scale;
+  spany = (maxy - miny) * scale;
+  fits_x = spanx <= content_w - margin;
+  fits_y = spany <= content_h - margin;
+  fits = fits_x && fits_y;
 
-  if (pn != NULL && view_seen (view, pn->key))
+  cx = (int) ((minx + maxx) / 2.0 * scale);
+  cy = (int) ((miny + maxy) / 2.0 * scale);
+
+  follow_now = follow && pn != NULL && !pn->hidden && view_seen (view, pn->key);
+
+  if (!fits && follow_now)
     {
-      int spanx = (maxx - minx) * scale;
-      int spany = (maxy - miny) * scale;
-      int lo, hi;
-      if (spanx > dst->w - 24)
+      /* LockPlayerCentre on whichever axis overflows. */
+      if (!fits_x)
         {
-          cam->cx = (int) ((pn->x + pn->w / 2.0) * scale);
-          lo = minx * scale + (dst->w - 24) / 2;
-          hi = maxx * scale - (dst->w - 24) / 2;
-          if (cam->cx < lo)
-            cam->cx = lo;
-          if (cam->cx > hi)
-            cam->cx = hi;
+          cx = (int) ((pn->x + pn->w / 2.0) * scale);
+          lo = minx * scale + (content_w - margin) / 2;
+          hi = maxx * scale - (content_w - margin) / 2;
+          if (cx < lo)
+            cx = lo;
+          if (cx > hi)
+            cx = hi;
         }
-      if (spany > dst->h - 24)
+      if (!fits_y)
         {
-          cam->cy = (int) ((pn->y + pn->h / 2.0) * scale);
-          lo = miny * scale + (dst->h - 24) / 2;
-          hi = maxy * scale - (dst->h - 24) / 2;
-          if (cam->cy < lo)
-            cam->cy = lo;
-          if (cam->cy > hi)
-            cam->cy = hi;
+          cy = (int) ((pn->y + pn->h / 2.0) * scale);
+          lo = miny * scale + (content_h - margin) / 2;
+          hi = maxy * scale - (content_h - margin) / 2;
+          if (cy < lo)
+            cy = lo;
+          if (cy > hi)
+            cy = hi;
         }
     }
+  else if (!fits)
+    {
+      /* User pan, or a hidden player room: keep the previous centre and clamp. */
+      cx = prev_cx;
+      cy = prev_cy;
+      if (fits_x)
+        cx = (int) ((minx + maxx) / 2.0 * scale);
+      else
+        {
+          lo = minx * scale + (content_w - margin) / 2;
+          hi = maxx * scale - (content_w - margin) / 2;
+          if (cx < lo)
+            cx = lo;
+          if (cx > hi)
+            cx = hi;
+        }
+      if (fits_y)
+        cy = (int) ((miny + maxy) / 2.0 * scale);
+      else
+        {
+          lo = miny * scale + (content_h - margin) / 2;
+          hi = maxy * scale - (content_h - margin) / 2;
+          if (cy < lo)
+            cy = lo;
+          if (cy > hi)
+            cy = hi;
+        }
+    }
+
+  cam->cx = cx;
+  cam->cy = cy;
+  return fits;
+}
+
+/* --- floating pan/zoom chrome ------------------------------------------- */
+
+#define MAP_BTN_SIZE 22
+#define MAP_BTN_GAP 3
+#define MAP_BTN_PAD 4
+#define MAP_CLUSTER_GAP 8
+#define MAP_BTN_ALPHA 230       /* ~90% opaque */
+
+typedef struct {
+  int id;
+  int x, y, w, h;
+} map_btn_t;
+
+/* Lay out the chrome buttons into `out` (at most 6), right-aligned in `win_w`.
+   Returns the count.  When `fits`, only +/− are present. */
+static int
+map_chrome_layout (int win_w, int fits, map_btn_t *out, int out_max)
+{
+  int n = 0, i, x, y = MAP_BTN_PAD, total;
+
+  if (out_max < 2)
+    return 0;
+
+  /* Width of the row we are about to place, then right-align it. */
+  if (fits)
+    total = MAP_BTN_SIZE * 2 + MAP_BTN_GAP;
+  else
+    total = MAP_BTN_SIZE * 4 + MAP_BTN_GAP * 3   /* pan */
+            + MAP_CLUSTER_GAP
+            + MAP_BTN_SIZE * 2 + MAP_BTN_GAP;     /* zoom */
+  x = win_w - MAP_BTN_PAD - total;
+  if (x < MAP_BTN_PAD)
+    x = MAP_BTN_PAD;
+
+  if (!fits)
+    {
+      static const int pan_ids[] = {
+        MAP_CHROME_PAN_L, MAP_CHROME_PAN_R,
+        MAP_CHROME_PAN_U, MAP_CHROME_PAN_D
+      };
+      for (i = 0; i < 4 && n < out_max; i++)
+        {
+          out[n].id = pan_ids[i];
+          out[n].x = x;
+          out[n].y = y;
+          out[n].w = MAP_BTN_SIZE;
+          out[n].h = MAP_BTN_SIZE;
+          n++;
+          x += MAP_BTN_SIZE + (i < 3 ? MAP_BTN_GAP : MAP_CLUSTER_GAP);
+        }
+    }
+
+  if (n < out_max)
+    {
+      out[n].id = MAP_CHROME_ZOOM_IN;
+      out[n].x = x;
+      out[n].y = y;
+      out[n].w = MAP_BTN_SIZE;
+      out[n].h = MAP_BTN_SIZE;
+      n++;
+    }
+  x += MAP_BTN_SIZE + MAP_BTN_GAP;
+  if (n < out_max)
+    {
+      out[n].id = MAP_CHROME_ZOOM_OUT;
+      out[n].x = x;
+      out[n].y = y;
+      out[n].w = MAP_BTN_SIZE;
+      out[n].h = MAP_BTN_SIZE;
+      n++;
+    }
+  return n;
+}
+
+static void
+fill_round_rect (map_surface_t *s, int x0, int y0, int x1, int y1,
+                 int r, unsigned int rgb, int alpha)
+{
+  int x, y;
+  if (r < 1)
+    {
+      fill_rect (s, x0, y0, x1, y1, rgb, alpha);
+      return;
+    }
+  fill_rect (s, x0 + r, y0, x1 - r, y1, rgb, alpha);
+  fill_rect (s, x0, y0 + r, x0 + r, y1 - r, rgb, alpha);
+  fill_rect (s, x1 - r, y0 + r, x1, y1 - r, rgb, alpha);
+  for (y = 0; y <= r; y++)
+    for (x = 0; x <= r; x++)
+      if (x * x + y * y <= r * r)
+        {
+          blend (s, x0 + r - x, y0 + r - y, rgb, alpha);
+          blend (s, x1 - r + x, y0 + r - y, rgb, alpha);
+          blend (s, x0 + r - x, y1 - r + y, rgb, alpha);
+          blend (s, x1 - r + x, y1 - r + y, rgb, alpha);
+        }
+}
+
+static void
+draw_chrome_arrow (map_surface_t *s, int cx, int cy, int dx, int dy,
+                   unsigned int rgb, int alpha)
+{
+  /* A small filled triangle pointing along (dx,dy). */
+  draw_arrowhead (s, (double) cx + dx * 3, (double) cy + dy * 3,
+                  (double) dx, (double) dy, 5, rgb, alpha);
+}
+
+static void
+draw_chrome_btn (map_surface_t *s, const map_btn_t *b, int enabled)
+{
+  unsigned int face, ink;
+  int cx = b->x + b->w / 2;
+  int cy = b->y + b->h / 2;
+  int alpha = MAP_BTN_ALPHA;
+
+  ensure_derived_palette ();
+  face = mix_rgb (map_bg, map_fg, enabled ? 0.12 : 0.06);
+  ink = enabled ? map_fg : mix_rgb (map_fg, map_bg, 0.55);
+
+  fill_round_rect (s, b->x, b->y, b->x + b->w - 1, b->y + b->h - 1,
+                   4, face, alpha);
+  draw_rect (s, b->x, b->y, b->x + b->w - 1, b->y + b->h - 1,
+             ink, enabled ? alpha : alpha / 2);
+
+  switch (b->id)
+    {
+    case MAP_CHROME_PAN_L:
+      draw_chrome_arrow (s, cx, cy, -1, 0, ink, enabled ? 255 : 140);
+      break;
+    case MAP_CHROME_PAN_R:
+      draw_chrome_arrow (s, cx, cy, 1, 0, ink, enabled ? 255 : 140);
+      break;
+    case MAP_CHROME_PAN_U:
+      draw_chrome_arrow (s, cx, cy, 0, -1, ink, enabled ? 255 : 140);
+      break;
+    case MAP_CHROME_PAN_D:
+      draw_chrome_arrow (s, cx, cy, 0, 1, ink, enabled ? 255 : 140);
+      break;
+    case MAP_CHROME_ZOOM_IN:
+    case MAP_CHROME_ZOOM_OUT:
+      {
+        /* The 8x8 cells leave empty columns on the right, so centre on the
+           ink width rather than the cell. */
+        unsigned char ch = (b->id == MAP_CHROME_ZOOM_IN) ? '+' : '-';
+        int ink_w = glyph_advance (&kBigFont, ch) - 1;
+        if (ink_w < 1)
+          ink_w = kBigFont.w;
+        draw_glyph (s, &kBigFont, ch,
+                    cx - ink_w / 2, cy - kBigFont.h / 2,
+                    ink, enabled ? 255 : 140);
+      }
+      break;
+    }
+}
+
+void
+map_chrome_draw (map_surface_t *dst, int fits,
+                 int zoom_in_enabled, int zoom_out_enabled,
+                 int pan_can)
+{
+  map_btn_t btns[6];
+  int n, i;
+
+  if (dst == NULL)
+    return;
+  n = map_chrome_layout (dst->w, fits, btns, 6);
+  for (i = 0; i < n; i++)
+    {
+      int enabled = 1;
+      switch (btns[i].id)
+        {
+        case MAP_CHROME_PAN_L:
+          enabled = (pan_can & MAP_PAN_CAN_L) != 0;
+          break;
+        case MAP_CHROME_PAN_R:
+          enabled = (pan_can & MAP_PAN_CAN_R) != 0;
+          break;
+        case MAP_CHROME_PAN_U:
+          enabled = (pan_can & MAP_PAN_CAN_U) != 0;
+          break;
+        case MAP_CHROME_PAN_D:
+          enabled = (pan_can & MAP_PAN_CAN_D) != 0;
+          break;
+        case MAP_CHROME_ZOOM_IN:
+          enabled = zoom_in_enabled;
+          break;
+        case MAP_CHROME_ZOOM_OUT:
+          enabled = zoom_out_enabled;
+          break;
+        default:
+          break;
+        }
+      draw_chrome_btn (dst, &btns[i], enabled);
+    }
+}
+
+int
+map_chrome_hit (int w, int h, int fits,
+                int zoom_in_enabled, int zoom_out_enabled,
+                int pan_can, int px, int py)
+{
+  map_btn_t btns[6];
+  int n, i;
+
+  (void) h;
+  (void) zoom_in_enabled;
+  (void) zoom_out_enabled;
+  (void) pan_can;              /* caller decides whether to act */
+  n = map_chrome_layout (w, fits, btns, 6);
+  for (i = 0; i < n; i++)
+    {
+      const map_btn_t *b = &btns[i];
+      if (px < b->x || py < b->y || px >= b->x + b->w || py >= b->y + b->h)
+        continue;
+      return b->id;
+    }
+  return MAP_CHROME_NONE;
+}
+
+void
+map_pan_nudge_delta (const map_camera_t *cam, int w, int h,
+                     int *out_dx, int *out_dy)
+{
+  int chrome = cam != NULL ? cam->chrome_h : 0;
+  int content_h = h - chrome;
+  if (content_h < 1)
+    content_h = 1;
+  if (out_dx)
+    *out_dx = w / 4;
+  if (out_dy)
+    *out_dy = content_h / 4;
+  if (out_dx && *out_dx < 16)
+    *out_dx = 16;
+  if (out_dy && *out_dy < 16)
+    *out_dy = 16;
+}
+
+int
+map_pan_can (const map_t *map, const map_view_t *view,
+             const map_camera_t *cam, int w, int h)
+{
+  const map_page_t *page;
+  int i, minx = 0, miny = 0, maxx = 0, maxy = 0, first = 1;
+  int chrome, content_w, content_h, margin = 24;
+  int scale, spanx, spany, lo, hi, can = 0;
+
+  if (map == NULL || cam == NULL || w <= 0 || h <= 0)
+    return 0;
+  page = page_by_key (map, cam->page);
+  if (page == NULL)
+    return 0;
+
+  for (i = 0; i < page->n_nodes; i++)
+    {
+      const map_node_t *n = &page->nodes[i];
+      if (!view_seen (view, n->key))
+        continue;
+      if (first)
+        {
+          minx = n->x;
+          miny = n->y;
+          maxx = n->x + n->w;
+          maxy = n->y + n->h;
+          first = 0;
+        }
+      else
+        {
+          if (n->x < minx)
+            minx = n->x;
+          if (n->y < miny)
+            miny = n->y;
+          if (n->x + n->w > maxx)
+            maxx = n->x + n->w;
+          if (n->y + n->h > maxy)
+            maxy = n->y + n->h;
+        }
+    }
+  if (first)
+    return 0;
+
+  chrome = cam->chrome_h;
+  if (chrome < 0)
+    chrome = 0;
+  content_w = w;
+  content_h = h - chrome;
+  if (content_h < 1)
+    content_h = 1;
+  scale = cam->scale;
+  spanx = (maxx - minx) * scale;
+  spany = (maxy - miny) * scale;
+
+  /* An axis that fits is locked to the extent centre: no pan either way. */
+  if (spanx > content_w - margin)
+    {
+      lo = minx * scale + (content_w - margin) / 2;
+      hi = maxx * scale - (content_w - margin) / 2;
+      if (cam->cx > lo)
+        can |= MAP_PAN_CAN_L;
+      if (cam->cx < hi)
+        can |= MAP_PAN_CAN_R;
+    }
+  if (spany > content_h - margin)
+    {
+      lo = miny * scale + (content_h - margin) / 2;
+      hi = maxy * scale - (content_h - margin) / 2;
+      if (cam->cy > lo)
+        can |= MAP_PAN_CAN_U;
+      if (cam->cy < hi)
+        can |= MAP_PAN_CAN_D;
+    }
+  return can;
 }
 
 /* An exit that leads somewhere the player has not been is drawn as a short

--- a/terps/scarier/mapdraw.cpp
+++ b/terps/scarier/mapdraw.cpp
@@ -1419,7 +1419,7 @@ map_has_content (const map_t *map, const map_view_t *view,
 int
 map_zoom_step (int scale, int dir)
 {
-  static const int ladder[] = { 3, 4, 5, 6, 8, 10, 12, 16, 20, 26, 32 };
+  static const int ladder[] = { 10, 12, 16, 20, 26, 32 };
   const int n = (int) (sizeof ladder / sizeof ladder[0]);
   int i;
 

--- a/terps/scarier/mapdraw.h
+++ b/terps/scarier/mapdraw.h
@@ -212,23 +212,75 @@ typedef struct map_camera_s {
   int page;                   /* page to draw                                */
   int scale;                  /* pixels per map unit (runner default 10)     */
   int cx, cy;                 /* centre of the view, in map units * scale    */
+  int chrome_h;               /* top strip reserved for pan/zoom buttons;
+                                 shifts the projection so the map sits under
+                                 the chrome.  0 for headless dumps.          */
 } map_camera_t;
 
-/* Pick the page the player is on and frame it.  With `zoom` 0, fits the seen
-   nodes to `dst` (clamped between MAP_SCALE_MIN and MAP_SCALE_MAX) and centres
-   on the player, like the runner's LockPlayerCentre.  A positive `zoom` pins
-   the scale to that many pixels per map unit instead (a manual "glk zoom");
-   the centring still runs, so the view pans to keep the player on-screen. */
+/* Height of the floating pan/zoom button row (padding included). */
+#define MAP_CHROME_H 30
+
+/* Pick the page and frame the seen extent into the content area under
+   `chrome_h`.  With `zoom` 0, fits to that area (clamped between
+   MAP_SCALE_MIN and MAP_SCALE_MAX).  A positive `zoom` pins the scale.
+   When the extent fits, the view is centred on it.  When it does not:
+   `follow` recentres on the player (LockPlayerCentre); otherwise the
+   caller's cam->cx/cy are kept and re-clamped.  A hidden or missing player
+   room never follows -- the previous centre is retained.  Returns whether
+   the extent fits at the chosen scale.  When `out_fit_scale` is non-NULL it
+   receives the auto-fit scale (even under a manual zoom), so the host can
+   disable zoom-out at the floor where the map fits. */
 #define MAP_SCALE_MIN 3
 #define MAP_SCALE_MAX 16
-extern void map_frame (const map_t *map, const map_view_t *view,
-                       const char *player_key, const map_surface_t *dst,
-                       int zoom, map_camera_t *cam);
+extern int map_frame (const map_t *map, const map_view_t *view,
+                      const char *player_key, const map_surface_t *dst,
+                      int zoom, int follow, int chrome_h,
+                      map_camera_t *cam, int *out_fit_scale);
 
 /* The next manual zoom level in from (dir > 0) or out from (dir <= 0) `scale`
    pixels per map unit.  Returns `scale` unchanged at the end of the range,
    which is how a caller knows to warn instead of redraw. */
 extern int map_zoom_step (int scale, int dir);
+
+/* Floating pan/zoom chrome over the map surface. */
+enum {
+  MAP_CHROME_NONE = 0,
+  MAP_CHROME_PAN_L,
+  MAP_CHROME_PAN_R,
+  MAP_CHROME_PAN_U,
+  MAP_CHROME_PAN_D,
+  MAP_CHROME_ZOOM_IN,
+  MAP_CHROME_ZOOM_OUT
+};
+
+/* Draw the button row (right-aligned).  When `fits`, the pan buttons are
+   omitted.  `pan_can` is a mask of MAP_PAN_CAN_* bits: directions that still
+   have travel room are drawn enabled; the rest are greyed.  Zoom-in/out are
+   greyed when their enabled flags are clear (zoom-out when already at the
+   auto-fit floor; zoom-in at the top of the ladder). */
+extern void map_chrome_draw (map_surface_t *dst, int fits,
+                             int zoom_in_enabled, int zoom_out_enabled,
+                             int pan_can);
+
+/* Which chrome button contains (px,py), or MAP_CHROME_NONE.  Greyed controls
+   (disabled pan, greyed zoom) still return their id so the host can swallow
+   the click. */
+extern int map_chrome_hit (int w, int h, int fits,
+                           int zoom_in_enabled, int zoom_out_enabled,
+                           int pan_can, int px, int py);
+
+/* Nudge size for one pan-button press: about a quarter of the content view. */
+extern void map_pan_nudge_delta (const map_camera_t *cam, int w, int h,
+                                 int *out_dx, int *out_dy);
+
+/* Which pan directions still have room to travel from `cam` (MAP_PAN_CAN_*
+   bits).  Returns 0 when the map fits on both axes. */
+#define MAP_PAN_CAN_L 1
+#define MAP_PAN_CAN_R 2
+#define MAP_PAN_CAN_U 4
+#define MAP_PAN_CAN_D 8
+extern int map_pan_can (const map_t *map, const map_view_t *view,
+                        const map_camera_t *cam, int w, int h);
 
 /* Draw the map.  Only rooms the player has seen are drawn (as in both
    runners); the player's own room is highlighted. */

--- a/terps/scarier/mapdraw.h
+++ b/terps/scarier/mapdraw.h
@@ -230,7 +230,7 @@ typedef struct map_camera_s {
    the extent fits at the chosen scale.  When `out_fit_scale` is non-NULL it
    receives the auto-fit scale (even under a manual zoom), so the host can
    disable zoom-out at the floor where the map fits. */
-#define MAP_SCALE_MIN 3
+#define MAP_SCALE_MIN 10
 #define MAP_SCALE_MAX 16
 extern int map_frame (const map_t *map, const map_view_t *view,
                       const char *player_key, const map_surface_t *dst,

--- a/terps/scarier/os_glk.cpp
+++ b/terps/scarier/os_glk.cpp
@@ -417,16 +417,25 @@ static int gsc_map_taken = FALSE;
 static scr_int gsc_map_restarts = 0;
 static void gsc_map_redraw (void);
 static void gsc_map_set_colourful (int colourful);
+static int gsc_map_chrome_click (int px, int py);
+static int gsc_map_zoom_apply (int dir);
 
 /* The camera and pixel size of the last map redraw, so a mouse click can be
    hit-tested against exactly what is on screen. */
 static map_camera_t gsc_map_cam;
 static int gsc_map_px_w = 0, gsc_map_px_h = 0;
+static int gsc_map_fits = TRUE;
+static int gsc_map_fit_scale = MAP_SCALE_MAX;
+static int gsc_map_pan_can = 0;
+/* Recentre on the player when the map does not fit; cleared by a pan button,
+   restored by moving to a different (visible) room. */
+static int gsc_map_follow = TRUE;
+static char gsc_map_last_player[64];
 
 /* A manual zoom ("glk zoom in/out"), as pixels per map unit; 0 while the map
    is fitting itself to its window ("glk zoom auto", the default).  A manual
    zoom is kept until "auto" puts it back; meanwhile the view pans to keep the
-   player on-screen. */
+   player on-screen when follow is set. */
 static int gsc_map_zoom = 0;
 
 /* The pixels currently on screen, kept so that a redraw need only send the rows
@@ -6203,6 +6212,13 @@ gsc_event_wait_2 (glui32 wait_type_1, glui32 wait_type_2, event_t * event)
               char here[16];
               const char *hit;
 
+              if (gsc_map_chrome_click ((int) event->val1, (int) event->val2))
+                {
+                  if (glk_gestalt (gestalt_MouseInput, wintype_Graphics))
+                    glk_request_mouse_event (gsc_map_window);
+                  break;
+                }
+
               scmap_view ((scr_gameref_t) gsc_game, &view);
               hit = map_hit (gsc_map, &view, &gsc_map_cam,
                              gsc_map_px_w, gsc_map_px_h,
@@ -7233,6 +7249,13 @@ gsc_a5_await_line (event_t *event, char *buf, int bufsize,
               a5_state_t *st = a5run_state (gsc_a5_run);
               const char *hit, *here;
 
+              if (gsc_map_chrome_click ((int) event->val1, (int) event->val2))
+                {
+                  if (glk_gestalt (gestalt_MouseInput, wintype_Graphics))
+                    glk_request_mouse_event (gsc_map_window);
+                  break;
+                }
+
               gsc_a5_map_view (st, &view);
               hit = map_hit (gsc_map, &view, &gsc_map_cam,
                                gsc_map_px_w, gsc_map_px_h,
@@ -8211,6 +8234,10 @@ gsc_stash_frontend_state (ScarierGlkFrontendState *st)
   st->map_shown = gsc_map_shown;
   st->map_at_top = gsc_map_at_top;
   st->map_zoom = gsc_map_zoom;
+  st->map_follow = gsc_map_follow;
+  st->map_cx = gsc_map_cam.cx;
+  st->map_cy = gsc_map_cam.cy;
+  st->map_page = gsc_map_cam.page;
   st->map_colourful = gsc_map_colourful;
   st->colour_on = gsc_colour_enabled;
 
@@ -8261,6 +8288,11 @@ gsc_recover_frontend_state (const ScarierGlkFrontendState *st)
   gsc_map_shown = st->map_shown;
   gsc_map_at_top = st->map_at_top;
   gsc_map_zoom = st->map_zoom;
+  gsc_map_follow = st->map_follow;
+  gsc_map_cam.cx = st->map_cx;
+  gsc_map_cam.cy = st->map_cy;
+  gsc_map_cam.page = st->map_page;
+  gsc_map_last_player[0] = '\0';
   /* The renderer is a fresh process's, at its default; the scheme has to be
      named again or the restored map would come back in the standard colours. */
   gsc_map_set_colourful (st->map_colourful);
@@ -9177,7 +9209,9 @@ gsc_a5_map_view (a5_state_t *st, map_view_t *view)
  * room you are in and the rooms you have seen, both of which change as you
  * play, and the runner likewise recomputed it every time it drew.
  *
- * Returns FALSE if there is no map to show.
+ * Returns FALSE if there is no map to show.  Mid-game ADRIFT 4 HideOnMap keeps
+ * the previous layout so the pan/zoom view can freeze on the last-known map
+ * instead of wiping the pane.
  */
 static int
 gsc_map_current (map_view_t *view, const char **player, char *keybuf,
@@ -9199,10 +9233,22 @@ gsc_map_current (map_view_t *view, const char **player, char *keybuf,
     return FALSE;
 
   scmap_view ((scr_gameref_t) gsc_game, view);
-  map_free (gsc_map);
-  gsc_map = scmap_build ((scr_gameref_t) gsc_game, view);
-  if (gsc_map == NULL)
-    return FALSE;
+  {
+    map_t *built = scmap_build ((scr_gameref_t) gsc_game, view);
+
+    if (built == NULL)
+      {
+        /* No layout from this room.  Keep a previous one if we have it
+           (HideOnMap mid-game); otherwise there is nothing to show yet. */
+        if (gsc_map == NULL)
+          return FALSE;
+      }
+    else
+      {
+        map_free (gsc_map);
+        gsc_map = built;
+      }
+  }
 
   snprintf (keybuf, (size_t) keysize, "%ld",
             (long) gs_playerroom ((scr_gameref_t) gsc_game));
@@ -9247,6 +9293,123 @@ gsc_map_worth_opening (void)
 }
 
 /*
+ * gsc_map_zoom_apply()
+ *
+ * Step the manual zoom in (dir > 0) or out (dir <= 0).  Zoom-out will not go
+ * below the auto-fit scale for the current window; at that floor it returns to
+ * auto.  Returns TRUE if the zoom changed.
+ */
+static int
+gsc_map_zoom_apply (int dir)
+{
+  int scale, stepped;
+
+  scale = gsc_map_zoom > 0 ? gsc_map_zoom : gsc_map_cam.scale;
+  if (scale < MAP_SCALE_MIN)
+    scale = 10;
+
+  if (dir <= 0)
+    {
+      stepped = map_zoom_step (scale, -1);
+      if (stepped < gsc_map_fit_scale || stepped == scale)
+        {
+          if (gsc_map_zoom == 0)
+            return FALSE;
+          gsc_map_zoom = 0;
+          gsc_map_redraw ();
+          return TRUE;
+        }
+      gsc_map_zoom = stepped;
+      gsc_map_redraw ();
+      return TRUE;
+    }
+
+  stepped = map_zoom_step (scale, 1);
+  if (stepped == scale)
+    return FALSE;
+  gsc_map_zoom = stepped;
+  gsc_map_redraw ();
+  return TRUE;
+}
+
+/*
+ * gsc_map_chrome_click()
+ *
+ * Handle a click on the floating pan/zoom buttons.  Returns TRUE if the click
+ * was consumed (including a greyed zoom-out that should not walk).
+ */
+static int
+gsc_map_chrome_click (int px, int py)
+{
+  int scale = gsc_map_cam.scale;
+  int zoom_in_ok = map_zoom_step (scale, 1) != scale;
+  int zoom_out_ok = scale > gsc_map_fit_scale;
+  int id = map_chrome_hit (gsc_map_px_w, gsc_map_px_h, gsc_map_fits,
+                           zoom_in_ok, zoom_out_ok, gsc_map_pan_can, px, py);
+  int dx = 0, dy = 0;
+  int pan_bit = 0;
+
+  if (id == MAP_CHROME_NONE)
+    return FALSE;
+
+  /* Greyed zoom: swallow the click so it does not walk to a room. */
+  if (id == MAP_CHROME_ZOOM_IN && !zoom_in_ok)
+    return TRUE;
+  if (id == MAP_CHROME_ZOOM_OUT && !zoom_out_ok)
+    return TRUE;
+
+  switch (id)
+    {
+    case MAP_CHROME_PAN_L:
+      pan_bit = MAP_PAN_CAN_L;
+      break;
+    case MAP_CHROME_PAN_R:
+      pan_bit = MAP_PAN_CAN_R;
+      break;
+    case MAP_CHROME_PAN_U:
+      pan_bit = MAP_PAN_CAN_U;
+      break;
+    case MAP_CHROME_PAN_D:
+      pan_bit = MAP_PAN_CAN_D;
+      break;
+    default:
+      break;
+    }
+  if (pan_bit != 0)
+    {
+      /* Greyed pan: swallow without moving. */
+      if ((gsc_map_pan_can & pan_bit) == 0)
+        return TRUE;
+      gsc_map_follow = FALSE;
+      map_pan_nudge_delta (&gsc_map_cam, gsc_map_px_w, gsc_map_px_h, &dx, &dy);
+      if (id == MAP_CHROME_PAN_L)
+        gsc_map_cam.cx -= dx;
+      else if (id == MAP_CHROME_PAN_R)
+        gsc_map_cam.cx += dx;
+      else if (id == MAP_CHROME_PAN_U)
+        gsc_map_cam.cy -= dy;
+      else
+        gsc_map_cam.cy += dy;
+      gsc_map_redraw ();
+      return TRUE;
+    }
+
+  switch (id)
+    {
+    case MAP_CHROME_ZOOM_IN:
+      gsc_map_zoom_apply (1);
+      return TRUE;
+
+    case MAP_CHROME_ZOOM_OUT:
+      gsc_map_zoom_apply (-1);
+      return TRUE;
+
+    default:
+      return FALSE;
+    }
+}
+
+/*
  * gsc_map_redraw()
  *
  * Rasterise the map and blit it into the graphics window.  Glk has no drawing
@@ -9267,6 +9430,7 @@ gsc_map_redraw (void)
   char keybuf[16];
   glui32 w, h;
   int x, y;
+  int zoom_in_ok, zoom_out_ok;
 
   /* A map that was asked for while there was nothing on it: try again now
      that the game has moved on.  (gsc_map_show comes straight back here, but
@@ -9300,9 +9464,8 @@ gsc_map_redraw (void)
       }
   }
 
-  /* Nothing to draw: an ADRIFT 4 layout that gave up, or a player standing in a
-     room hidden from the map -- where the runner showed an empty map too.  Wipe
-     the pane rather than leave the last one up; it will come back by itself. */
+  /* Nothing to draw yet: no map has ever been built (opening staging room).
+     Mid-game HideOnMap keeps the previous layout via gsc_map_current. */
   if (!gsc_map_current (&view, &ploc, keybuf, sizeof keybuf))
     {
       glk_window_clear (gsc_map_window);
@@ -9310,12 +9473,34 @@ gsc_map_redraw (void)
       return;
     }
 
+  /* Moving to a different visible room restores follow-the-player.  A hidden
+     room leaves the camera where it was.  The first redraw after open/restore
+     only records the room -- it must not override a restored pan. */
+  if (ploc != NULL)
+    {
+      if (gsc_map_last_player[0] != '\0'
+          && strcmp (ploc, gsc_map_last_player) != 0)
+        {
+          const map_node_t *pn = map_find (gsc_map, ploc);
+
+          if (pn != NULL && !pn->hidden)
+            gsc_map_follow = TRUE;
+        }
+      snprintf (gsc_map_last_player, sizeof gsc_map_last_player, "%s", ploc);
+    }
+
   surf = map_surface_new ((int) w, (int) h);
   if (surf == NULL)
     return;
 
-  map_frame (gsc_map, &view, ploc, surf, gsc_map_zoom, &gsc_map_cam);
+  gsc_map_fits = map_frame (gsc_map, &view, ploc, surf, gsc_map_zoom,
+                            gsc_map_follow, MAP_CHROME_H, &gsc_map_cam,
+                            &gsc_map_fit_scale);
   map_render (gsc_map, &view, ploc, &gsc_map_cam, surf);
+  zoom_in_ok = map_zoom_step (gsc_map_cam.scale, 1) != gsc_map_cam.scale;
+  zoom_out_ok = gsc_map_cam.scale > gsc_map_fit_scale;
+  gsc_map_pan_can = map_pan_can (gsc_map, &view, &gsc_map_cam, surf->w, surf->h);
+  map_chrome_draw (surf, gsc_map_fits, zoom_in_ok, zoom_out_ok, gsc_map_pan_can);
   gsc_map_px_w = surf->w;
   gsc_map_px_h = surf->h;
   if (gsc_is_a5)
@@ -9675,6 +9860,8 @@ gsc_map_show (void)
       return;
     }
   gsc_map_shown = TRUE;
+  gsc_map_follow = TRUE;
+  gsc_map_last_player[0] = '\0';
   gsc_map_screen_drop ();       /* a fresh window holds nothing */
   gsc_map_redraw ();
 
@@ -9869,6 +10056,8 @@ gsc_map_notice_restart (void)
   stream = glk_stream_get_current ();
   gsc_map_hide ();
   gsc_map_zoom = 0;
+  gsc_map_follow = TRUE;
+  gsc_map_last_player[0] = '\0';
   gsc_map_auto_reveal ();
   glk_stream_set_current (stream);
 }
@@ -10062,7 +10251,7 @@ gsc_command_map (const char *argument)
 static void
 gsc_command_zoom (const char *argument)
 {
-  int in, scale, stepped;
+  int in;
 
   if (gsc_is_a5 ? gsc_a5_run == NULL : gsc_game == NULL)
     return;
@@ -10109,18 +10298,12 @@ gsc_command_zoom (const char *argument)
 
   /* Step from the manual zoom, or from wherever the automatic fit last
      landed; a map with nothing drawn yet steps from the runner's default. */
-  scale = gsc_map_zoom > 0 ? gsc_map_zoom : gsc_map_cam.scale;
-  if (scale < MAP_SCALE_MIN)
-    scale = 10;
-  stepped = map_zoom_step (scale, in ? 1 : -1);
-  if (stepped == scale)
+  if (!gsc_map_zoom_apply (in ? 1 : -1))
     {
       gsc_normal_string (in ? "The map is already at its maximum zoom.\n"
                             : "The map is already at its minimum zoom.\n");
       return;
     }
-  gsc_map_zoom = stepped;
-  gsc_map_redraw ();
 }
 
 
@@ -10212,6 +10395,8 @@ gsc_a5_restart_run (a5_run_t *&run)
      close in. */
   gsc_map_hide ();
   gsc_map_zoom = 0;
+  gsc_map_follow = TRUE;
+  gsc_map_last_player[0] = '\0';
 
   glk_window_clear (gsc_main_window);
   gsc_main_window_empty = TRUE;

--- a/terps/scarier/scarier-autosave.h
+++ b/terps/scarier/scarier-autosave.h
@@ -84,6 +84,13 @@ struct ScarierGlkFrontendState {
     int map_shown = 0;
     int map_at_top = 0;
     int map_zoom = 0;
+    /* Pan/zoom chrome: follow-the-player, and the last camera centre so a
+     * mid-pan autosave comes back looking the same.  Older autosaves decode
+     * follow as 0, which is fine -- the next room change restores it. */
+    int map_follow = 1;
+    int map_cx = 0;
+    int map_cy = 0;
+    int map_page = 0;
     /* "glk map colour": which of the two schemes the map is drawn in.  An
      * autosave written before this field existed decodes as 0, the standard
      * colours, which is what those sessions restored as anyway. */

--- a/terps/scarier/scarier-autosave.mm
+++ b/terps/scarier/scarier-autosave.mm
@@ -152,6 +152,10 @@ static void scarier_library_archive(TempLibrary *library, NSCoder *encoder)
     [encoder encodeInt32:st->map_shown forKey:@"scarier_map_shown"];
     [encoder encodeInt32:st->map_at_top forKey:@"scarier_map_at_top"];
     [encoder encodeInt32:st->map_zoom forKey:@"scarier_map_zoom"];
+    [encoder encodeInt32:st->map_follow forKey:@"scarier_map_follow"];
+    [encoder encodeInt32:st->map_cx forKey:@"scarier_map_cx"];
+    [encoder encodeInt32:st->map_cy forKey:@"scarier_map_cy"];
+    [encoder encodeInt32:st->map_page forKey:@"scarier_map_page"];
     [encoder encodeInt32:st->map_colourful forKey:@"scarier_map_colourful"];
     [encoder encodeInt32:st->colour_on forKey:@"scarier_colour_on"];
     [encoder encodeInt32:st->rng_usenative forKey:@"scarier_rng_usenative"];
@@ -186,6 +190,12 @@ static void scarier_library_unarchive(TempLibrary *library, NSCoder *decoder)
     st->map_shown = [decoder decodeInt32ForKey:@"scarier_map_shown"];
     st->map_at_top = [decoder decodeInt32ForKey:@"scarier_map_at_top"];
     st->map_zoom = [decoder decodeInt32ForKey:@"scarier_map_zoom"];
+    st->map_follow =
+        [decoder containsValueForKey:@"scarier_map_follow"]
+            ? [decoder decodeInt32ForKey:@"scarier_map_follow"] : 1;
+    st->map_cx = [decoder decodeInt32ForKey:@"scarier_map_cx"];
+    st->map_cy = [decoder decodeInt32ForKey:@"scarier_map_cy"];
+    st->map_page = [decoder decodeInt32ForKey:@"scarier_map_page"];
     st->map_colourful = [decoder decodeInt32ForKey:@"scarier_map_colourful"];
     st->colour_on = [decoder decodeInt32ForKey:@"scarier_colour_on"];
     st->rng_usenative =

--- a/terps/scarier/test/adrift4/harness/scmap_dump.cpp
+++ b/terps/scarier/test/adrift4/harness/scmap_dump.cpp
@@ -130,7 +130,7 @@ static void
 draw_and_exit (void)
 {
   map_surface_t *surf;
-  map_camera_t cam;
+  map_camera_t cam = { 0 };
   map_view_t view;
   map_t *map;
   char player[16];
@@ -166,7 +166,7 @@ draw_and_exit (void)
                      (unsigned int) (g_fg >= 0 ? g_fg : 0x000000));
   map_set_colour_scheme (g_colour ? MAP_SCHEME_DERIVED : MAP_SCHEME_STANDARD);
   surf = map_surface_new (g_width, g_height);
-  map_frame (map, &view, player, surf, 0, &cam);
+  map_frame (map, &view, player, surf, 0, 1, 0, &cam, NULL);
   map_render (map, &view, player, &cam, surf);
   fprintf (stderr, "scale=%d\n", cam.scale);
 

--- a/terps/scarier/test/adrift5/harness/a5map_dump.cpp
+++ b/terps/scarier/test/adrift5/harness/a5map_dump.cpp
@@ -82,7 +82,7 @@ main (int argc, char **argv)
   a5_run_t *run;
   map_t *map;
   map_surface_t *surf;
-  map_camera_t cam;
+  map_camera_t cam = { 0 };
   ctx_t ctx;
   map_view_t view;
   const char *out = "map.ppm";
@@ -207,7 +207,7 @@ main (int argc, char **argv)
        PrepareForNextTurn emptied the per-turn route memo, so stale in-turn
        blocked results must not decide connector visibility. */
     a5restr_route_cache_clear (ctx.st);
-    map_frame (map, &view, ploc, surf, 0, &cam);
+    map_frame (map, &view, ploc, surf, 0, 1, 0, &cam, NULL);
     map_render (map, &view, ploc, &cam, surf);
     fprintf (stderr, "player=%s page=%d scale=%d content=%d\n",
              ploc ? ploc : "(none)", cam.page, cam.scale,


### PR DESCRIPTION
… and increase minimum zoom scale to 10

(Filed as draft because it will conflict with #170, and I want to merge that first.)

* Fixes #175 

When the window is very small, we clamp to zoom scale 10, and don't permit zooming out further, but you can still use the pan controls to browse the entire map.

<img width="927" height="541" alt="image" src="https://github.com/user-attachments/assets/fe101fe1-7c76-4786-b312-bb49fd680635" />

When the window is large enough to show the entire map, the pan buttons are hidden.

<img width="1170" height="619" alt="image" src="https://github.com/user-attachments/assets/f58d3843-1352-44aa-bf34-d81525469923" />

If you can pan in at least one direction, pan buttons are visible, but if you're already at the edge of the map, unusable pan buttons are disabled.

<img width="1170" height="619" alt="image" src="https://github.com/user-attachments/assets/49751764-ab35-479d-8119-5b1c138559c0" />
