### PR TITLE
Add support for `glk_style_measure` of weight, oblique, proportional, and size

### DIFF
--- a/SpatterlightTests/StyleMeasureTests.m
+++ b/SpatterlightTests/StyleMeasureTests.m
@@ -361,4 +361,69 @@
     XCTAssertEqual(measured, expected);
 }
 
+#pragma mark - Font trait measures (Weight / Oblique / Proportional)
+
+- (NSInteger)fontTraitValueForStyle:(GlkStyle *)style hint:(NSUInteger)hint {
+    NSFont *font = style.attributeDict[NSFontAttributeName];
+    XCTAssertNotNil(font);
+    NSFontTraitMask traits = [[NSFontManager sharedFontManager] traitsOfFont:font];
+    switch (hint) {
+        case stylehint_Weight:
+            return (traits & NSBoldFontMask) ? 1 : 0;
+        case stylehint_Oblique:
+            return (traits & NSItalicFontMask) ? 1 : 0;
+        case stylehint_Proportional:
+            return ((traits & NSFixedPitchFontMask) || font.isFixedPitch) ? 0 : 1;
+        default:
+            XCTFail(@"unexpected hint %lu", (unsigned long)hint);
+            return -1;
+    }
+}
+
+// Theme-backed font traits must measure without a game stylehint (the gap the
+// stylemeasure.ulx probe hit: weight/oblique/proportional used to FAIL).
+- (void)testBufferMeasureFontTraitsFromTheme {
+    GlkController *ctl = [self makeController];
+    GlkTextBufferWindow *win = [[GlkTextBufferWindow alloc] initWithGlkController:ctl name:1];
+
+    XCTAssertEqual([self measureWindow:win controller:ctl style:style_Normal hint:stylehint_Weight],
+                   [self fontTraitValueForStyle:self.theme.bufferNormal hint:stylehint_Weight]);
+    XCTAssertEqual([self measureWindow:win controller:ctl style:style_Normal hint:stylehint_Oblique],
+                   [self fontTraitValueForStyle:self.theme.bufferNormal hint:stylehint_Oblique]);
+    XCTAssertEqual([self measureWindow:win controller:ctl style:style_Normal hint:stylehint_Proportional],
+                   [self fontTraitValueForStyle:self.theme.bufferNormal hint:stylehint_Proportional]);
+
+    // Preformatted is fixed-width in the default theme.
+    XCTAssertEqual([self measureWindow:win controller:ctl style:style_Preformatted hint:stylehint_Proportional],
+                   [self fontTraitValueForStyle:self.theme.bufPre hint:stylehint_Proportional]);
+    XCTAssertEqual([self measureWindow:win controller:ctl style:style_Preformatted hint:stylehint_Proportional], 0);
+}
+
+// With doStyles on, a Weight hint applied before the window opens must show
+// through measure via the style table font (not only via getStyleVal).
+- (void)testMeasureReflectsWeightHintWhenStylesEnabled {
+    GlkController *ctl = [self makeController];
+    ctl.bufferStyleHints[style_User1][stylehint_Weight] = @(1);
+
+    GlkTextBufferWindow *win = [[GlkTextBufferWindow alloc] initWithGlkController:ctl name:1];
+
+    XCTAssertEqual([self measureWindow:win controller:ctl style:style_User1 hint:stylehint_Weight], 1);
+}
+
+// With doStyles off, an unused Weight hint must not show through: measure the
+// theme font, matching the colour-hint contract.
+- (void)testMeasureIgnoresWeightHintWhenStylesDisabled {
+    self.theme.doStyles = NO;
+
+    GlkController *ctl = [self makeController];
+    ctl.bufferStyleHints[style_User1][stylehint_Weight] = @(1);
+
+    GlkTextBufferWindow *win = [[GlkTextBufferWindow alloc] initWithGlkController:ctl name:1];
+
+    NSInteger expected = [self fontTraitValueForStyle:self.theme.bufUsr1 hint:stylehint_Weight];
+    XCTAssertEqual([self measureWindow:win controller:ctl style:style_User1 hint:stylehint_Weight], expected);
+    XCTAssertNotEqual(expected, 1,
+                      @"fixture: theme User1 should not already be bold, or the test proves nothing");
+}
+
 @end

--- a/SpatterlightTests/StyleMeasureTests.m
+++ b/SpatterlightTests/StyleMeasureTests.m
@@ -361,7 +361,7 @@
     XCTAssertEqual(measured, expected);
 }
 
-#pragma mark - Font trait measures (Weight / Oblique / Proportional)
+#pragma mark - Font trait measures (Weight / Oblique / Proportional / Size)
 
 - (NSInteger)fontTraitValueForStyle:(GlkStyle *)style hint:(NSUInteger)hint {
     NSFont *font = style.attributeDict[NSFontAttributeName];
@@ -374,6 +374,8 @@
             return (traits & NSItalicFontMask) ? 1 : 0;
         case stylehint_Proportional:
             return ((traits & NSFixedPitchFontMask) || font.isFixedPitch) ? 0 : 1;
+        case stylehint_Size:
+            return (NSInteger)llround(font.pointSize);
         default:
             XCTFail(@"unexpected hint %lu", (unsigned long)hint);
             return -1;
@@ -392,6 +394,10 @@
                    [self fontTraitValueForStyle:self.theme.bufferNormal hint:stylehint_Oblique]);
     XCTAssertEqual([self measureWindow:win controller:ctl style:style_Normal hint:stylehint_Proportional],
                    [self fontTraitValueForStyle:self.theme.bufferNormal hint:stylehint_Proportional]);
+    XCTAssertEqual([self measureWindow:win controller:ctl style:style_Normal hint:stylehint_Size],
+                   [self fontTraitValueForStyle:self.theme.bufferNormal hint:stylehint_Size]);
+    XCTAssertGreaterThan([self measureWindow:win controller:ctl style:style_Normal hint:stylehint_Size], 1,
+                         @"Size must be a real point/CSS-px size, not the old stub value 1");
 
     // Preformatted is fixed-width in the default theme.
     XCTAssertEqual([self measureWindow:win controller:ctl style:style_Preformatted hint:stylehint_Proportional],
@@ -399,6 +405,17 @@
     XCTAssertEqual([self measureWindow:win controller:ctl style:style_Preformatted hint:stylehint_Proportional], 0);
 }
 
+// A Size stylehint (±2 pt per step for buffers) must show through absolute measure.
+- (void)testMeasureReflectsSizeHintWhenStylesEnabled {
+    GlkController *ctl = [self makeController];
+    ctl.bufferStyleHints[style_User1][stylehint_Size] = @(1);
+
+    GlkTextBufferWindow *win = [[GlkTextBufferWindow alloc] initWithGlkController:ctl name:1];
+
+    NSInteger base = [self fontTraitValueForStyle:self.theme.bufUsr1 hint:stylehint_Size];
+    NSInteger measured = [self measureWindow:win controller:ctl style:style_User1 hint:stylehint_Size];
+    XCTAssertEqual(measured, base + 2);
+}
 // With doStyles on, a Weight hint applied before the window opens must show
 // through measure via the style table font (not only via getStyleVal).
 - (void)testMeasureReflectsWeightHintWhenStylesEnabled {

--- a/application/GlkController/GlkController+GlkRequests.m
+++ b/application/GlkController/GlkController+GlkRequests.m
@@ -357,10 +357,11 @@
                            hint:(NSUInteger)hint
                          result:(NSInteger *)result {
 
+    // Measure the style table only (theme +/- stylehints applied at window
+    // creation), not live zcolor or reverse video — same model as Gargoyle.
+    NSDictionary *attributes = [gwindow baseAttributesForStyle:style];
+
     if (hint == stylehint_TextColor || hint == stylehint_BackColor) {
-        // Measure the style table only (theme +/- stylehints), not live
-        // zcolor or reverse video — same model as Gargoyle.
-        NSDictionary *attributes = [gwindow baseAttributesForStyle:style];
         NSColor *color = nil;
         if (hint == stylehint_TextColor) {
             color = attributes[NSForegroundColorAttributeName];
@@ -375,6 +376,28 @@
         if (color) {
             *result = color.integerColor;
             return YES;
+        }
+    }
+
+    if (hint == stylehint_Weight || hint == stylehint_Oblique || hint == stylehint_Proportional) {
+        NSFont *font = attributes[NSFontAttributeName];
+        if (!font)
+            return NO;
+
+        NSFontTraitMask traits = [[NSFontManager sharedFontManager] traitsOfFont:font];
+        switch (hint) {
+            case stylehint_Weight:
+                // Glk: 1 bold, 0 normal, -1 light. Report bold vs not (as Gargoyle does).
+                *result = (traits & NSBoldFontMask) ? 1 : 0;
+                return YES;
+            case stylehint_Oblique:
+                *result = (traits & NSItalicFontMask) ? 1 : 0;
+                return YES;
+            case stylehint_Proportional:
+                *result = ((traits & NSFixedPitchFontMask) || font.isFixedPitch) ? 0 : 1;
+                return YES;
+            default:
+                break;
         }
     }
 

--- a/application/GlkController/GlkController+GlkRequests.m
+++ b/application/GlkController/GlkController+GlkRequests.m
@@ -379,7 +379,8 @@
         }
     }
 
-    if (hint == stylehint_Weight || hint == stylehint_Oblique || hint == stylehint_Proportional) {
+    if (hint == stylehint_Weight || hint == stylehint_Oblique ||
+        hint == stylehint_Proportional || hint == stylehint_Size) {
         NSFont *font = attributes[NSFontAttributeName];
         if (!font)
             return NO;
@@ -395,6 +396,11 @@
                 return YES;
             case stylehint_Proportional:
                 *result = ((traits & NSFixedPitchFontMask) || font.isFixedPitch) ? 0 : 1;
+                return YES;
+            case stylehint_Size:
+                // Absolute size in density-independent pixels (AppKit points ≈ CSS px),
+                // matching RemGlk/AsyncGlk's Math.round(computed.fontSize).
+                *result = (NSInteger)llround(font.pointSize);
                 return YES;
             default:
                 break;

--- a/glkimp/stylehint.c
+++ b/glkimp/stylehint.c
@@ -36,10 +36,6 @@ glui32 glk_style_measure(winid_t win, glui32 styl, glui32 hint, glui32 *result)
         case stylehint_Justification:
             *result = stylehint_just_LeftFlush;
             return TRUE;
-            
-        case stylehint_Size:
-            *result = 1;
-            return TRUE;
 
         default:
             res = win_style_measure(win->peer, styl, hint, result);


### PR DESCRIPTION
Fixes #183

<img width="852" height="1104" alt="image" src="https://github.com/user-attachments/assets/fe9386bf-cc74-4b0b-b813-2310a8b5582b" />

