### PR TITLE
Fix garglk compile failures on gcc 9

### DIFF
--- a/terps/scarier/sclibrar.cpp
+++ b/terps/scarier/sclibrar.cpp
@@ -29,6 +29,7 @@
 
 #include <assert.h>
 #include <limits.h>
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -12169,7 +12170,7 @@ lib_battle_player_strike (scr_gameref_t game, scr_int npc,
  * for the Battle System falls through, leaving non-battle games' behaviour for
  * these words exactly as it was.
  */
-static /*
+/*
  * lib_battle_absent_npc_400()
  *
  * The 4.0 battle parser dobattle (Proc_11_4_47F084, entered from


### PR DESCRIPTION
1. Missing `#include <math.h>` (Xcode lets you get away without it)
2. Stray `static` from https://github.com/angstsmurf/spatterlight/commit/0743cefef#diff-17767bd711cf09a87934fe68e2724fd982a2a74d08da84a33363984a56b35479R10856